### PR TITLE
fix: ensure consistent vertical spacing across homepage sections

### DIFF
--- a/app/newComponents/faq-section.tsx
+++ b/app/newComponents/faq-section.tsx
@@ -35,7 +35,7 @@ export function FAQSection() {
   };
 
   return (
-    <section className="py-20">
+    <section className="py-8 lg:py-20">
       <div className="container mx-auto px-4 max-w-3xl">
         <div className="text-center mb-16">
           <h2 className="text-3xl md:text-4xl font-bold mb-4">FAQs</h2>

--- a/app/newComponents/hero-section.tsx
+++ b/app/newComponents/hero-section.tsx
@@ -13,7 +13,7 @@ export function HeroSection() {
         backgroundRepeat: "no-repeat",
       }}
     >
-      <div className="max-w-[1200px] mx-auto flex flex-col items-center justify-center text-center px-6 py-20 md:py-32">
+      <div className="max-w-[1200px] mx-auto flex flex-col items-center justify-center text-center px-6 py-8 lg:py-20">
         <h1 className="text-4xl md:text-6xl lg:text-[64px] font-bold text-white mb-6 leading-tight">
           Public or Private Events.
           <br />

--- a/app/newComponents/host-in-peace.tsx
+++ b/app/newComponents/host-in-peace.tsx
@@ -1,7 +1,7 @@
 import { ArrowUpRight } from "lucide-react";
 export function HostInPeace() {
   return (
-    <section className="py-20 bg-white">
+    <section className="py-8 lg:py-20 bg-white">
       <div className="container mx-auto px-4 text-center">
         <h2 className="text-[30px] md:text-[40px] text-[#2C0A4A] font-bold mb-4">
           Host in Peace. No

--- a/app/newComponents/how-it-works.tsx
+++ b/app/newComponents/how-it-works.tsx
@@ -24,7 +24,7 @@ export function HowItWorks() {
   ];
 
   return (
-    <section className="max-w-[1200px] mx-auto">
+    <section className="max-w-[1200px] mx-auto py-8 lg:py-20">
       <div className="mx-auto px-4">
         <div className="text-center mb-16">
           <h2 className="text-[#2C0A4A] text-[30px] md:text-[40px] font-bold mb-4">

--- a/app/newComponents/no-signups-section.tsx
+++ b/app/newComponents/no-signups-section.tsx
@@ -2,7 +2,7 @@ import Image from "next/image";
 
 export function NoSignupsSection() {
   return (
-    <section className="py-20">
+    <section className="py-8 lg:py-20">
       <div className="mx-auto px-4 text-center">
         <h2 className="text-[40px] md:text-[80px] text-[#2C0A4A] mb-4">
           No Signups{" "}

--- a/app/newComponents/powerful-tools.tsx
+++ b/app/newComponents/powerful-tools.tsx
@@ -40,7 +40,7 @@ export function PowerfulTools() {
   ];
 
   return (
-    <section className="py-20 bg-white">
+    <section className="py-8 lg:py-20 bg-white">
       <div className="max-w-[1200px] mx-auto flex flex-col md:flex-row justify-center items-center gap-10">
         <div className="w-full">
           <h2 className="text-[24px] md:text-[40px] md:text-left text-center text-[#2C0A4A] font-bold mb-4">

--- a/app/newComponents/trending-events.tsx
+++ b/app/newComponents/trending-events.tsx
@@ -109,7 +109,7 @@ export function TrendingEvents() {
   };
 
   return (
-    <section className="py-12 md:py-16 lg:py-20 bg-white">
+    <section className="py-8 lg:py-20 bg-white">
       <div className="container mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center mb-8 md:mb-12 gap-4">
           <h2 className="text-2xl sm:text-3xl lg:text-[32px] text-[#2C0A4A] font-bold">

--- a/app/newComponents/trending-news.tsx
+++ b/app/newComponents/trending-news.tsx
@@ -60,7 +60,7 @@ export function TrendingNews() {
   ];
 
   return (
-    <section className="max-w-[1200px] mx-auto py-20">
+    <section className="max-w-[1200px] mx-auto py-8 lg:py-20">
       <div className="mx-auto px-4">
         <div className="flex justify-between items-center mb-12">
           <h2 className="text-3xl font-bold">Trending News</h2>


### PR DESCRIPTION
## Description  
This PR fixes the inconsistent vertical spacing between homepage sections by aligning the layout with the Figma design specifications.  

## Changes Made  
- Applied `py-8 lg:py-20` to all homepage sections to match vertical spacing (30px mobile, 80px desktop).  
- Ensured consistent separation between:  
  - Hero section  
  - How it works section  
  - No signups section  
  - Trending events section  
  - Powerful tools section  
  - FAQ section  
  - Host in Peace section  
  - Trending news section  
- Verified responsiveness across desktop, tablet, and mobile.  
- Confirmed no overlapping or excessive spacing between sections.  
- Tested across major browsers for consistent rendering.  

## Related Issue  
Closes #32  
