### PR TITLE
feat: cancel registration modal with blur, animations, and styling fixes

### DIFF
--- a/app/components/TicketCancellationModal.tsx
+++ b/app/components/TicketCancellationModal.tsx
@@ -1,11 +1,7 @@
 'use client'
 
 import React, { useState } from 'react'
-import {
-  Dialog,
-  DialogContent,
-  DialogOverlay
-} from '@/components/ui/dialog'
+import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
 import { X, Ticket } from 'lucide-react'
 
@@ -13,19 +9,19 @@ interface TicketCancellationModalProps {
   isOpen: boolean
   onClose: () => void
   ticketId: string
-  userId: string
-  isConfirmed: boolean
-  isPaid: boolean
-  onConfirm: (ticketId: string, userId: string, updatedState: { isConfirmed: boolean, isPaid: boolean }) => void
+  userId?: string
+  isConfirmed?: boolean
+  isPaid?: boolean
+  onConfirm?: (ticketId: string, userId: string, updatedState: { isConfirmed: boolean; isPaid: boolean }) => void
 }
 
 export function TicketCancellationModal({
   isOpen,
   onClose,
   ticketId,
-  userId,
-  isConfirmed,
-  isPaid,
+  userId = '',
+  isConfirmed = false,
+  isPaid = false,
   onConfirm
 }: TicketCancellationModalProps) {
   const [isProcessing, setIsProcessing] = useState(false)
@@ -39,30 +35,30 @@ export function TicketCancellationModal({
     setIsProcessing(true)
 
     try {
-      // Console log the data as requested
-      console.log('Cancelling ticket:', {
+      // Placeholder: replace with real API call when backend is ready
+      // e.g. await fetch(`/api/registrations/${ticketId}/cancel`, { method: 'POST' })
+      console.log('Cancel registration API (placeholder):', { ticketId, userId })
+
+      const payload = {
         ticketId,
         userId,
         previousState: { isConfirmed, isPaid },
         newState: { isConfirmed: false, isPaid: false }
-      })
+      }
+      console.log('Cancelling ticket:', payload)
 
       // Simulate API call delay
       await new Promise(resolve => setTimeout(resolve, 500))
 
-      // Call the parent handler to update state
-      onConfirm(ticketId, userId, { isConfirmed: false, isPaid: false })
+      onConfirm?.(ticketId, userId, { isConfirmed: false, isPaid: false })
 
-      // Show success message
       setShowSuccess(true)
 
-      // Auto-close after 2 seconds
       setTimeout(() => {
         setShowSuccess(false)
         setIsProcessing(false)
         onClose()
       }, 2000)
-
     } catch (error) {
       console.error('Error cancelling ticket:', error)
       setIsProcessing(false)
@@ -77,49 +73,50 @@ export function TicketCancellationModal({
 
   return (
     <Dialog open={isOpen} onOpenChange={handleOpenChange}>
-      <DialogOverlay className="fixed inset-0 z-50 bg-white/40 backdrop-blur-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0" />
       <DialogContent
-        className="fixed left-[50%] top-[50%] z-50 gap-0 w-full bg-white max-w-[90vw] md:max-w-[375px] md:mx-4 translate-x-[-50%] translate-y-[-50%]  rounded-2xl shadow-lg p-6 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 duration-200 border-0 sm:mx-0 font-work-sans"
+        overlayClassName="bg-white/40 backdrop-blur-md"
+        className="fixed left-[50%] top-[50%] z-50 gap-0 w-full bg-white max-w-[90vw] md:max-w-[375px] translate-x-[-50%] translate-y-[-50%] rounded-2xl shadow-lg p-4 sm:p-6 mx-4 md:mx-0 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 duration-200 border-0 font-work-sans"
         showCloseButton={false}
       >
         {!showSuccess ? (
           <>
             <div className="flex items-center justify-between mb-4 border-b border-gray-200 pb-4">
               <div className="flex items-center gap-2">
-                <Ticket className="w-5 h-5 -rotate-45 text-gray-600" />
-                <span className="text-lg font-medium text-gray-900 ">Ticket</span>
+                <Ticket className="w-5 h-5 -rotate-45 text-gray-500" aria-hidden />
+                <DialogTitle className="text-lg font-medium text-gray-900">Ticket</DialogTitle>
               </div>
               <button
+                type="button"
                 onClick={handleDiscard}
-                className="rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none cursor-pointer"
+                className="rounded-sm opacity-70 transition-opacity hover:opacity-100 focus:outline-none focus:ring-0 disabled:pointer-events-none cursor-pointer text-primary"
                 disabled={isProcessing}
+                aria-label="Close"
               >
-                <X className="h-5 w-5" color="#6917AF" />
+                <X className="h-5 w-5" strokeWidth={2} />
                 <span className="sr-only">Close</span>
               </button>
             </div>
 
-            {/* Modal content */}
-            <div className="mb-4">
-              <p className="text-gray-700 text-base font-semibold leading-relaxed">
+            <div className="mb-5">
+              <p className="text-gray-700 text-base leading-relaxed">
                 Are you sure you want to cancel your registration. We'll let the host know that you can't make it.
               </p>
             </div>
 
-            {/* Action buttons */}
-            <div className="flex gap-3">
+            <div className="flex flex-col-reverse gap-3 sm:flex-row">
               <Button
+                type="button"
                 onClick={handleDiscard}
                 disabled={isProcessing}
-                className="flex-1 bg-primary hover:bg-[#5a1496] text-white font-semibold p-6 rounded-full transition-colors duration-200 cursor-pointer"
+                className="flex-1 bg-primary hover:bg-[#5a1496] text-white font-semibold py-3 px-5 sm:p-6 rounded-full transition-colors duration-200 cursor-pointer"
               >
                 Discard
               </Button>
               <Button
+                type="button"
                 onClick={handleConfirm}
                 disabled={isProcessing}
-                variant="outline"
-                className="flex-1 border-2 border-gray-300 text-gray-700 hover:bg-gray-50 font-semibold p-6 rounded-full transition-colors duration-200 cursor-pointer"
+                className="flex-1 border-2 border-[#6917af] text-[#6917af] bg-white font-semibold py-3 px-5 sm:p-6 rounded-full cursor-pointer hover:bg-white hover:text-[#6917af] shadow-none"
               >
                 {isProcessing ? 'Processing...' : 'Yes'}
               </Button>
@@ -133,7 +130,7 @@ export function TicketCancellationModal({
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
               </svg>
             </div>
-            <h3 className="text-lg font-medium text-gray-900 mb-2">Registration Cancelled</h3>
+            <DialogTitle className="text-lg font-medium text-gray-900 mb-2">Registration Cancelled</DialogTitle>
             <p className="text-gray-600">The host has been notified of your cancellation.</p>
           </div>
         )}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -9,6 +9,7 @@ import { FAQSection } from "./newComponents/faq-section";
 import { HostInPeace } from "./newComponents/host-in-peace";
 import { TrendingNews } from "./newComponents/trending-news";
 import { QRCodeModalExample } from "./components/QRCodeModalExample";
+import { TicketCancellationModalExample } from "./components/TicketCancellationModalExample";
 // import { Footer } from "@/components/footer"
 export default function HomePage() {
   return (
@@ -23,9 +24,10 @@ export default function HomePage() {
       <HostInPeace />
       <TrendingNews />
       
-      {/* QR Code Modal Test - Remove after testing */}
-      <div className="py-10">
+      {/* Modal demos - Remove after testing */}
+      <div className="py-10 flex flex-wrap gap-8 justify-center">
         <QRCodeModalExample />
+        <TicketCancellationModalExample />
       </div>
     </div>
   );

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -50,13 +50,15 @@ function DialogContent({
   className,
   children,
   showCloseButton = true,
+  overlayClassName,
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Content> & {
   showCloseButton?: boolean
+  overlayClassName?: string
 }) {
   return (
     <DialogPortal data-slot="dialog-portal">
-      <DialogOverlay />
+      <DialogOverlay className={overlayClassName} />
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(

--- a/package-lock.json
+++ b/package-lock.json
@@ -2002,6 +2002,7 @@
       "integrity": "sha512-oxLPMytKchWGbnQM9O7D67uPa9paTNxO7jVoNMXgkkErULBPhPARCfkKL9ytcIJJRGjbsVwW4ugJzyFFvm/Tiw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -2012,6 +2013,7 @@
       "integrity": "sha512-XGJkWF41Qq305SKWEILa1O8vzhb3aOo3ogBlSmiqNko/WmRb6QIaweuZCXjKygVDXpzXb5wyxKTSOsmkuqj+Qw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.0.0"
       }
@@ -2818,6 +2820,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
       "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2827,6 +2830,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
       "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -2839,6 +2843,7 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.65.0.tgz",
       "integrity": "sha512-xtOzDz063WcXvGWaHgLNrNzlsdFgtUWcb32E6WFaGTd7kPZG3EeDusjdZfUsPwKCKVXy1ZlntifaHZ4l8pAsmw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -2862,6 +2867,7 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -2980,7 +2986,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",


### PR DESCRIPTION
## Cancel registration modal

Adds and wires up the cancel registration modal for both paid and free events, with blur, animations, responsive layout, and styling fixes.

### Changes

**Modal behavior & UX**
- **Backdrop blur:** When the modal is open, the background uses a blurred overlay (`bg-white/40 backdrop-blur-md`) via a new `overlayClassName` prop on `DialogContent`.
- **Entrance:** Modal opens with scale-up and fade-in (`zoom-in-95`, `fade-in-0`, `duration-200`).
- **Close:** Closing (X or Discard) uses scale-down and fade-out (`zoom-out-95`, `fade-out-0`).
- **Discard:** Only closes the modal.
- **Yes:** Runs the cancel flow (placeholder API + `console.log`), then optional `onConfirm` and success state with auto-close.

**Props & API**
- **Required:** `isOpen`, `onClose`, `ticketId`.
- **Optional:** `userId`, `isConfirmed`, `isPaid`, `onConfirm(ticketId, userId, updatedState)`.

**Styling**
- Typography and layout aligned with Figma (Work Sans, spacing, copy).
- **Yes button:** Purple border and text (`#6917af`), white background, no hover effect; uses explicit border classes so the shared `Button` outline variant doesn’t override.
- **X close:** Focus ring removed so there’s no visible border/ring around the icon.

**Accessibility**
- `DialogTitle` added for both main and success states so Radix’s `DialogContent` has an accessible title and the console warning is resolved.

**Responsiveness**
- Mobile: `max-w-[90vw]`, adjusted padding, buttons stack vertically on small screens (`flex-col-reverse`), touch-friendly sizing.

**Demo**
- `TicketCancellationModalExample` is rendered on the home page (with the existing QR code modal demo) so the cancel modal can be opened from the bottom of the page.

### Files touched
- `components/ui/dialog.tsx` – `overlayClassName` support on `DialogContent`.
- `app/components/TicketCancellationModal.tsx` – blur, animations, buttons, `ticketId`/optional props, placeholder API, styling and a11y fixes.
- `app/page.tsx` – render `TicketCancellationModalExample` in the modal demo section.

### How to test
1. Run the app and go to the home page.
2. Scroll to the bottom and open “Cancel Registration” in the Ticket Status card.
3. Confirm blur, open/close animations, X and Discard closing, and Yes triggering the placeholder cancel flow and success state.
4. Resize to mobile and confirm layout and tap targets.


### Closes: #57 