### PR TITLE
fix: align home page theme styling with news page (light/dark)

### DIFF
--- a/app/newComponents/faq-section.tsx
+++ b/app/newComponents/faq-section.tsx
@@ -38,7 +38,7 @@ export function FAQSection() {
     <section className="py-8 lg:py-20">
       <div className="container mx-auto px-4 max-w-3xl">
         <div className="text-center mb-16">
-          <h2 className="text-3xl md:text-4xl font-bold mb-4">FAQs</h2>
+          <h2 className="text-3xl md:text-4xl font-bold mb-4 text-[#2C0A4A] dark:text-[#D7B5F5]">FAQs</h2>
           <p className="text-[#6C6C6C] text-[16px]">
             Everything you need to know about using Zicket—how it works, what
             makes it private, and how you can join or host your next event.
@@ -54,7 +54,7 @@ export function FAQSection() {
                 onClick={() => toggleItem(index)}
                 className="w-full flex justify-between items-center text-left"
               >
-                <h3 className="font-semibold text-[#121212] text-[20px]">{faq.question}</h3>
+                <h3 className="font-semibold text-[#121212] dark:text-[#D7B5F5] text-[20px]">{faq.question}</h3>
                 {openItem === index ? (
                   <span className="flex items-center bg-[#6917AF] rounded-full p-1">
                     <Minus className="w-5 h-5 text-white transition-transform duration-200" />
@@ -67,7 +67,7 @@ export function FAQSection() {
               </button>
               {openItem === index && (
                 <div className="overflow-hidden border-t py-6">
-                  <p className="text-[#121212] text-[16px] animate-in slide-in-from-top-2 duration-200">
+                  <p className="text-[#121212] dark:text-[#D7B5F5] text-[16px] animate-in slide-in-from-top-2 duration-200">
                     {faq.answer}
                   </p>
                 </div>
@@ -76,7 +76,7 @@ export function FAQSection() {
           ))}
         </div>
         <div className="text-center mt-8">
-          <button className="mt-16 mx-auto flex border border-[#2C0A4A] rounded-full py-2 px-3 text-[#2C0A4a] cursor-pointer">
+          <button className="mt-16 mx-auto flex border border-[#2C0A4A] dark:border-[#D7B5F5] rounded-full py-2 px-3 text-[#2C0A4a] dark:text-[#D7B5F5] cursor-pointer">
             View More <ArrowUpRight className="w-5 h-5" />
           </button>
         </div>

--- a/app/newComponents/host-in-peace.tsx
+++ b/app/newComponents/host-in-peace.tsx
@@ -1,9 +1,9 @@
 import { ArrowUpRight } from "lucide-react";
 export function HostInPeace() {
   return (
-    <section className="py-8 lg:py-20 bg-white">
+    <section className="py-8 lg:py-20 bg-white dark:bg-[#141414]">
       <div className="container mx-auto px-4 text-center">
-        <h2 className="text-[30px] md:text-[40px] text-[#2C0A4A] font-bold mb-4">
+        <h2 className="text-[30px] md:text-[40px] text-[#2C0A4A] dark:text-[#D7B5F5] font-bold mb-4">
           Host in Peace. No
           <br />
           Spreadsheets or Stalkers.
@@ -12,7 +12,7 @@ export function HostInPeace() {
           Zicket gives creators and organizers tools to launch, ticket, <br />
           and manage events without compromising guest privacy.
         </p>
-        <button className="flex mx-auto border border-[#2C0A4A] rounded-full py-2 px-3 text-[#2C0A4a] cursor-pointer">
+        <button className="flex mx-auto border border-[#2C0A4A] dark:border-[#D7B5F5] rounded-full py-2 px-3 text-[#2C0A4a] dark:text-[#D7B5F5] cursor-pointer">
           Host An Event <ArrowUpRight className="w-5 h-5"/>
         </button>
       </div>

--- a/app/newComponents/how-it-works.tsx
+++ b/app/newComponents/how-it-works.tsx
@@ -27,7 +27,7 @@ export function HowItWorks() {
     <section className="max-w-[1200px] mx-auto py-8 lg:py-20">
       <div className="mx-auto px-4">
         <div className="text-center mb-16">
-          <h2 className="text-[#2C0A4A] text-[30px] md:text-[40px] font-bold mb-4">
+          <h2 className="text-[#2C0A4A] dark:text-[#D7B5F5] text-[30px] md:text-[40px] font-bold mb-4">
             How It Works
           </h2>
           <p className="text-[#6C6C6C] text-[16px]">
@@ -38,7 +38,7 @@ export function HowItWorks() {
           {steps.map((step, index) => (
             <div
               key={index}
-              className="text-left bg-[#FBFAF9] p-6 rounded-lg shadow-md hover:shadow-lg transition-shadow"
+              className="text-left bg-[#FBFAF9] dark:bg-[#181818] p-6 rounded-lg shadow-md hover:shadow-lg transition-shadow"
             >
               <div className="w-18 h-18 rounded-full flex items-center justify-center mb-6">
                  <Image 
@@ -51,7 +51,7 @@ export function HowItWorks() {
               </div>
 
 
-              <h3 className="text-[18px] text-[#2C0A4A] font-semibold mb-4">
+              <h3 className="text-[18px] text-[#2C0A4A] dark:text-[#D7B5F5] font-semibold mb-4">
                 {step.title}
               </h3>
               <p className="text-[#6C6C6C] text-[14px]">{step.description}</p>

--- a/app/newComponents/no-signups-section.tsx
+++ b/app/newComponents/no-signups-section.tsx
@@ -4,9 +4,9 @@ export function NoSignupsSection() {
   return (
     <section className="py-8 lg:py-20">
       <div className="mx-auto px-4 text-center">
-        <h2 className="text-[40px] md:text-[80px] text-[#2C0A4A] mb-4">
+        <h2 className="text-[40px] md:text-[80px] text-[#2C0A4A] dark:text-[#D7B5F5] mb-4">
           No Signups{" "}
-          <span className="text-[#2C0A4A]">
+          <span className="text-[#2C0A4A] dark:text-[#D7B5F5]">
             <Image
               src="/image 15.svg"
               alt="No sign ups required"

--- a/app/newComponents/powerful-tools.tsx
+++ b/app/newComponents/powerful-tools.tsx
@@ -40,10 +40,10 @@ export function PowerfulTools() {
   ];
 
   return (
-    <section className="py-8 lg:py-20 bg-white">
+    <section className="py-8 lg:py-20 bg-white dark:bg-[#141414]">
       <div className="max-w-[1200px] mx-auto flex flex-col md:flex-row justify-center items-center gap-10">
         <div className="w-full">
-          <h2 className="text-[24px] md:text-[40px] md:text-left text-center text-[#2C0A4A] font-bold mb-4">
+          <h2 className="text-[24px] md:text-[40px] md:text-left text-center text-[#2C0A4A] dark:text-[#D7B5F5] font-bold mb-4">
             Powerful Tools for
             <br />
             Public or Private Events.
@@ -52,14 +52,14 @@ export function PowerfulTools() {
             Privacy-first event hosting and ticketing. Build a More Private,
             Trusted Space for your community of fans.
           </p>
-          <button className="mt-16 flex border border-[#2C0A4A] md:mx-0 mx-auto rounded-full py-2 px-3 text-[#2C0A4a] cursor-pointer">
+          <button className="mt-16 flex border border-[#2C0A4A] dark:border-[#D7B5F5] md:mx-0 mx-auto rounded-full py-2 px-3 text-[#2C0A4a] dark:text-[#D7B5F5] cursor-pointer">
             Explore Events <ArrowUpRight className="w-5 h-5" />
           </button>
         </div>
         <div className="w-full grid grid-cols-2 md:grid-cols-4 gap-4">
           {tools.map((tool, index) => (
             <div key={index} className="text-center flex flex-col items-center">
-              <div className="w-[110px] h-[110px] flex justify-center items-center border border-[#797979] rounded-lg shadow-md hover:shadow-lg transition-shadow mb-4">
+              <div className="w-[110px] h-[110px] flex justify-center items-center border border-[#797979] dark:border-[#404040] rounded-lg shadow-md hover:shadow-lg transition-shadow mb-4">
                 <Image
                   width={60}
                   height={60}
@@ -72,7 +72,7 @@ export function PowerfulTools() {
                   className="w-[60px] h-[60px] object-cover rounded-lg"
                 />
               </div>
-              <h3 className="text-[11px]">{tool.title}</h3>
+              <h3 className="text-[11px] text-black dark:text-white">{tool.title}</h3>
             </div>
           ))}
         </div>

--- a/app/newComponents/trending-news.tsx
+++ b/app/newComponents/trending-news.tsx
@@ -63,7 +63,7 @@ export function TrendingNews() {
     <section className="max-w-[1200px] mx-auto py-8 lg:py-20">
       <div className="mx-auto px-4">
         <div className="flex justify-between items-center mb-12">
-          <h2 className="text-3xl font-bold">Trending News</h2>
+          <h2 className="text-3xl font-bold text-[#2C0A4A] dark:text-[#D7B5F5]">Trending News</h2>
           <div className="flex gap-2">
             <button
               className="w-9 h-9 flex items-center justify-center rounded-full cursor-pointer group"
@@ -210,7 +210,7 @@ export function TrendingNews() {
         </Swiper>
 
         <div className="flex justify-end mt-8">
-          <button className="bg-none border-b border-[#2C0A4A] text-[16px] font-bold text-[#2C0A4A] flex">
+          <button className="bg-none border-b border-[#2C0A4A] dark:border-[#D7B5F5] text-[16px] font-bold text-[#2C0A4A] dark:text-[#D7B5F5] flex">
             See All News <ArrowUpRight className="w-5 h-5 ml-2" />
           </button>
         </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -12,7 +12,7 @@ import { QRCodeModalExample } from "./components/QRCodeModalExample";
 // import { Footer } from "@/components/footer"
 export default function HomePage() {
   return (
-    <div className="min-h-screen bg-[#f6f0fb]">
+    <div className="min-h-screen bg-white dark:bg-[#141414]">
       <HeroSection />
       <HowItWorks />
       <NoSignupsSection />


### PR DESCRIPTION
## Summary
Updates the home page so its theme styling matches the `/news` page. The page now correctly supports light and dark themes with consistent typography, colors, and backgrounds. The hero section and the QR code component are unchanged.

## Problem
The home page used a fixed light background (`#f6f0fb`) and hardcoded light-only text/section colors. It did not respond to the app’s light/dark theme (e.g. from the header toggle), so it looked inconsistent with theme-aware pages like `/news`.

## Solution
- **Page wrapper:** Replaced `bg-[#f6f0fb]` with `bg-white dark:bg-[#141414]` so the root background follows the theme.
- **Sections:** Applied the same light/dark patterns used on `/news`:
  - **Headings:** `text-[#2C0A4A]` in light mode, `dark:text-[#D7B5F5]` in dark mode.
  - **Section backgrounds:** Sections that had `bg-white` now use `dark:bg-[#141414]` where appropriate.
  - **Cards:** Step and card areas use `dark:bg-[#181818]` and theme-aware borders where needed.
  - **Buttons/links:** Outline and text use `dark:border-[#D7B5F5]` and `dark:text-[#D7B5F5]` so they stay visible and on-brand in dark mode.
- **Secondary text:** Kept `#6C6C6C` for body/description text where it remains readable in both themes.

## Files changed
- `app/page.tsx` – theme-aware page background
- `app/newComponents/how-it-works.tsx` – headings, step cards, step titles
- `app/newComponents/no-signups-section.tsx` – main heading
- `app/newComponents/powerful-tools.tsx` – section bg, heading, button, tool card borders/titles
- `app/newComponents/faq-section.tsx` – FAQ heading, question/answer text, “View More” button
- `app/newComponents/host-in-peace.tsx` – section bg, heading, “Host An Event” button
- `app/newComponents/trending-news.tsx` – “Trending News” heading, “See All News” link

## Out of scope (unchanged)
- **Hero section** – left as-is per requirements.
- **QR code block** – left as-is (testing only).

## Testing
- [x] Toggle light/dark theme (e.g. header) and confirm home page background and all sections switch correctly.
- [x] Compare home vs `/news` in both themes: backgrounds, headings, and accents should align.
- [x] Confirm hero and QR code areas are unchanged.


<img width="1338" height="567" alt="Screenshot 2026-02-24 202205" src="https://github.com/user-attachments/assets/570e6a46-62ec-433b-a28d-6bf2b1f1dae7" />



### Closes: #58 