### PR TITLE
feat: implement blockchain-aware payment UX component #146

### DIFF
--- a/app/api/transactions/[txHash]/status/route.ts
+++ b/app/api/transactions/[txHash]/status/route.ts
@@ -1,0 +1,52 @@
+import { NextResponse } from "next/server";
+
+type TxRecord = {
+  createdAt: number;
+};
+
+const txStore = new Map<string, TxRecord>();
+
+const CONFIRMATION_DELAY_MS = 10_000;
+const FAILURE_RATE = 0.05;
+
+function getStatusForTx(hash: string): {
+  status: "pending" | "confirmed" | "failed";
+  error?: string;
+} {
+  let record = txStore.get(hash);
+
+  if (!record) {
+    record = { createdAt: Date.now() };
+    txStore.set(hash, record);
+  }
+
+  const elapsed = Date.now() - record.createdAt;
+
+  if (elapsed >= CONFIRMATION_DELAY_MS) {
+    if (Math.random() < FAILURE_RATE) {
+      txStore.delete(hash);
+      return { status: "failed", error: "Transaction reverted on-chain." };
+    }
+    return { status: "confirmed" };
+  }
+
+  return { status: "pending" };
+}
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ txHash: string }> },
+) {
+  const { txHash } = await params;
+
+  if (!txHash || typeof txHash !== "string") {
+    return NextResponse.json(
+      { error: "Missing transaction hash." },
+      { status: 400 },
+    );
+  }
+
+  const result = getStatusForTx(txHash);
+
+  return NextResponse.json(result);
+}

--- a/app/components/explore/EventCheckout/PurchasedStage.tsx
+++ b/app/components/explore/EventCheckout/PurchasedStage.tsx
@@ -18,10 +18,10 @@ export const PurchasedStage: FC<PurchasedStageProps> = ({
   return (
     <div className="p-8 border border-[#E9E9E9] rounded-2xl dark:border-[#232323] w-full bg-white dark:bg-[#0A0A0A] shadow-[0_4px_20px_rgba(0,0,0,0.03)] font-work-sans">
       {isConfirming && (
-        <div className="flex items-center gap-2 mb-5 bg-[#FFF8E7] border border-[#F6C90E] text-[#856404] py-3 px-4 rounded-lg">
+        <div className="flex items-center gap-2 mb-5 bg-[#F5EEFF] dark:bg-[#1C0F2E] border border-[#D4ADFC] dark:border-[#4A1F7A] text-[#6917AF] dark:text-[#D7B5F5] py-3 px-4 rounded-lg">
           <Loader2 className="animate-spin shrink-0" size={16} />
           <p className="text-xs font-medium">
-            Confirming on-chain… your ticket is reserved.
+            Confirming on-chain&hellip; your ticket is reserved.
           </p>
         </div>
       )}

--- a/app/components/explore/EventCheckout/TicketInfo.tsx
+++ b/app/components/explore/EventCheckout/TicketInfo.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { FC, useState, useEffect, useRef } from "react";
-import { Check, Loader2, CheckCircle2, XCircle } from "lucide-react";
+import { FC, useState, useEffect, useRef, useCallback } from "react";
+import { Check, Loader2, CheckCircle2 } from "lucide-react";
 import { useSimulatedAvailability } from "@/lib/hooks/useSimulatedAvailability";
 import {
   DangerIcon,
@@ -15,12 +15,13 @@ import {
 import { TicketType } from "@/lib/dummyEvents/events";
 import { loadWalletSDK, preloadWalletSDK, WalletLoadState } from "@/lib/walletSdk";
 import { useUserSessionSync } from "@/lib/user-session-sync";
+import { TransactionStatusBanner } from "@/components/TransactionStatusBanner";
+import type { TransactionStatus } from "@/hooks/useTransactionStatus";
 
-type TxStatus = "idle" | "pending" | "confirmed" | "failed";
 type PaymentStatus = "idle" | "processing" | "failed";
 
 interface TxState {
-  status: TxStatus;
+  status: TransactionStatus;
   txHash: string | null;
   error: string | null;
   attempts: number;
@@ -37,67 +38,18 @@ interface TicketInfoProps {
     isConfirmed: boolean;
     isPaid: boolean;
   }) => Promise<{ ok: boolean; error?: string }> | { ok: boolean; error?: string };
+  onResetPayment?: () => void;
 }
 
 const POLL_INTERVAL_MS = 3000;
+const MAX_POLL_ATTEMPTS = 20;
 
 async function fetchTxStatus(
   txHash: string
-): Promise<{ status: "pending" | "confirmed" | "failed"; error?: string }> {
+): Promise<{ status: TransactionStatus; error?: string }> {
   const res = await fetch(`/api/transactions/${txHash}/status`);
   if (!res.ok) throw new Error(`HTTP ${res.status}`);
   return res.json();
-}
-
-function TxBanner({ txState }: { txState: TxState }) {
-  if (txState.status === "idle") return null;
-
-  const configs = {
-    pending: {
-      icon: <Loader2 className="size-5 animate-spin text-[#6917AF]" />,
-      wrapper: "bg-[#F5EEFF] border-[#D4ADFC]",
-      text: "text-[#6917AF]",
-      title: "Transaction Pending",
-      message: "Confirming your ticket purchase on-chain…",
-    },
-    confirmed: {
-      icon: <CheckCircle2 className="size-5 text-[#039855]" />,
-      wrapper: "bg-[#ECFDF3] border-[#6CE9A6]",
-      text: "text-[#027A48]",
-      title: "Transaction Confirmed",
-      message: "Your ticket has been confirmed. You're all set!",
-    },
-    failed: {
-      icon: <XCircle className="size-5 text-[#D92D20]" />,
-      wrapper: "bg-[#FEF3F2] border-[#FDA29B]",
-      text: "text-[#B42318]",
-      title: "Transaction Failed",
-      message: txState.error ?? "Something went wrong. Please try again.",
-    },
-  } as const;
-
-  const cfg = configs[txState.status];
-  if (!cfg) return null;
-
-  return (
-    <div className={`flex gap-3 rounded-xl border px-4 py-3 ${cfg.wrapper}`}>
-      {cfg.icon}
-      <div className="flex-1 space-y-1">
-        <p className={`text-sm font-semibold ${cfg.text}`}>{cfg.title}</p>
-        <p className={`text-xs ${cfg.text}`}>{cfg.message}</p>
-
-        {txState.txHash && txState.status !== "pending" && (
-          
-          <a  href={`https://solscan.io/tx/${txState.txHash}`}
-            target="_blank"
-            className={`text-xs underline ${cfg.text}`}
-          >
-            View on Solscan ↗
-          </a>
-        )}
-      </div>
-    </div>
-  );
 }
 
 export const TicketInfo: FC<TicketInfoProps> = ({
@@ -108,6 +60,7 @@ export const TicketInfo: FC<TicketInfoProps> = ({
   paymentStatus = "idle",
   paymentError = null,
   onStatusChange,
+  onResetPayment,
 }) => {
   const { anonymousBrowsing, walletConnected, setAnonymousBrowsing, setWalletConnected } =
     useUserSessionSync();
@@ -160,22 +113,50 @@ export const TicketInfo: FC<TicketInfoProps> = ({
     try {
       const result = await fetchTxStatus(txHash);
 
-      setTxState((s) => ({
-        ...s,
-        status: result.status,
-        error: result.error ?? null,
-        attempts: s.attempts + 1,
-      }));
+      setTxState((s) => {
+        const nextAttempts = s.attempts + 1;
 
-      if (result.status !== "pending") {
+        if (nextAttempts >= MAX_POLL_ATTEMPTS && result.status === "pending") {
+          stopPolling();
+          return {
+            ...s,
+            status: "failed" as TransactionStatus,
+            error: "Transaction is taking longer than expected. Please check your wallet and try again.",
+            attempts: nextAttempts,
+          };
+        }
+
+        return {
+          ...s,
+          status: result.status,
+          error: result.error ?? null,
+          attempts: nextAttempts,
+        };
+      });
+
+      if (result.status === "confirmed") {
         stopPolling();
         await onStatusChange?.({
-          isConfirmed: result.status === "confirmed",
+          isConfirmed: true,
           isPaid,
         });
+      } else if (result.status === "failed") {
+        stopPolling();
       }
     } catch {
-      setTxState((s) => ({ ...s, attempts: s.attempts + 1 }));
+      setTxState((s) => {
+        const nextAttempts = s.attempts + 1;
+        if (nextAttempts >= MAX_POLL_ATTEMPTS) {
+          stopPolling();
+          return {
+            ...s,
+            status: "failed" as TransactionStatus,
+            error: "Unable to verify transaction. Please check your wallet and try again.",
+            attempts: nextAttempts,
+          };
+        }
+        return { ...s, attempts: nextAttempts };
+      });
     }
   };
 
@@ -216,6 +197,13 @@ export const TicketInfo: FC<TicketInfoProps> = ({
       });
     }
   };
+
+  const handleRetry = useCallback(() => {
+    stopPolling();
+    setTxState({ status: "idle", txHash: null, error: null, attempts: 0 });
+    setWalletState({ isLoading: false, error: null });
+    onResetPayment?.();
+  }, [onResetPayment]);
 
   const isButtonDisabled =
     walletState.isLoading ||
@@ -394,10 +382,17 @@ export const TicketInfo: FC<TicketInfoProps> = ({
           </div>
 
           {/* Tx banner */}
-          <TxBanner txState={txState} />
+          {txState.status !== "idle" && (
+            <TransactionStatusBanner
+              status={txState.status}
+              txHash={txState.txHash}
+              error={txState.error}
+              onRetry={txState.status === "failed" ? handleRetry : undefined}
+            />
+          )}
 
-          {/* Payment error */}
-          {hasPaymentFailed && (
+          {/* Payment error from parent (e.g. sold out, reconcile failure) */}
+          {hasPaymentFailed && txState.status === "idle" && (
             <div className="bg-[#FFF2F2] border border-[#FBCACA] text-[#B42318] py-3 px-5 rounded-lg">
               <p className="text-xs font-medium">
                 {paymentError ?? "Payment failed. Please retry."}
@@ -437,17 +432,6 @@ export const TicketInfo: FC<TicketInfoProps> = ({
             </button>
             {walletState.error && (
               <p className="mt-2 text-sm text-red-500">{walletState.error}</p>
-            )}
-            {txState.status === "failed" && (
-              <button
-                type="button"
-                onClick={() =>
-                  setTxState({ status: "idle", txHash: null, error: null, attempts: 0 })
-                }
-                className="text-sm underline mt-2"
-              >
-                Try again
-              </button>
             )}
           </div>
         </fieldset>

--- a/app/components/explore/EventDetailClient.tsx
+++ b/app/components/explore/EventDetailClient.tsx
@@ -47,6 +47,8 @@ export default function EventDetailClient({ event }: EventDetailClientProps) {
   const resetPaymentAttemptState = () => {
     setPaymentStatus("idle");
     setPaymentError(null);
+    setIsOptimistic(false);
+    setAttemptId(null);
   };
 
   const createAttemptId = () => {
@@ -188,6 +190,7 @@ export default function EventDetailClient({ event }: EventDetailClientProps) {
                 paymentStatus={paymentStatus}
                 paymentError={paymentError}
                 onStatusChange={handleStatusChange}
+                onResetPayment={resetPaymentAttemptState}
               />
             </div>
           </div>

--- a/components/TransactionStatusBanner.tsx
+++ b/components/TransactionStatusBanner.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import React from "react"
-import { CheckCircle2, XCircle, Loader2, Clock } from "lucide-react"
+import { CheckCircle2, XCircle, Loader2, RotateCcw } from "lucide-react"
 import { cn } from "@/lib/utils"
 import type { TransactionStatus } from "@/hooks/useTransactionStatus"
 import Link from "next/link";
@@ -12,6 +12,8 @@ export interface TransactionStatusBannerProps {
   error?: string | null
   pendingMessage?: string
   confirmedMessage?: string
+  failedMessage?: string
+  onRetry?: () => void
   className?: string
 }
 
@@ -54,6 +56,8 @@ export function TransactionStatusBanner({
   error,
   pendingMessage = "Confirming your ticket purchase…",
   confirmedMessage = "Ticket confirmed! You're all set.",
+  failedMessage,
+  onRetry,
   className,
 }: TransactionStatusBannerProps) {
   const config = CONFIG[status]
@@ -66,7 +70,7 @@ export function TransactionStatusBanner({
       ? pendingMessage
       : status === "confirmed"
       ? confirmedMessage
-      : (error ?? "Something went wrong. Please try again.")
+      : (failedMessage ?? error ?? "Something went wrong. Please try again.")
 
   return (
     <div
@@ -113,6 +117,21 @@ export function TransactionStatusBanner({
           <p className={cn("text-xs font-mono opacity-60 truncate", config.textClass)}>
             {txHash.slice(0, 12)}…{txHash.slice(-8)}
           </p>
+        )}
+
+        {/* Retry button on failure */}
+        {status === "failed" && onRetry && (
+          <button
+            type="button"
+            onClick={onRetry}
+            className={cn(
+              "mt-2 inline-flex items-center gap-1.5 text-xs font-semibold underline underline-offset-2",
+              config.textClass
+            )}
+          >
+            <RotateCcw size={12} />
+            Try again
+          </button>
         )}
       </div>
     </div>


### PR DESCRIPTION
## Description

Closes #146 

Implements a robust, blockchain-aware payment UX across the purchase flow. This PR cleanly models and displays the asynchronous lifecycle of on-chain transactions (`pending` → `confirmed` or `failed`), introduces concrete visual states to reduce UX confusion, and adds a coordinated retry mechanism for failed attempts.

---

## Changes

###  New
* **`app/api/transactions/[txHash]/status/route.ts`**
  * Implemented a mock blockchain transaction status endpoint to unblock the frontend. 
  * Returns `pending` for 10 seconds, then resolves to `confirmed` (95% chance) or `failed` (5% chance). *Note: The existing checkout hook was already polling this URL layout, but the route was missing.*

###  Refactored
* **`app/components/explore/EventCheckout/TicketInfo.tsx`**
  * Extracted inline `TxBanner` logic in favor of the shared `TransactionStatusBanner` component.
  * Added a safety threshold of max polling attempts (20) which safely triggers a timeout → `failed` state transition.
  * Prevented execution of `onStatusChange` on transaction failure to avoid redundant backend reconciliation cycles.
  * Introduced an `onResetPayment` callback prop to orchestrate clean state resets during a retry.
* **`app/components/explore/EventDetailClient.tsx`**
  * Updated `resetPaymentAttemptState` to cleanly wipe out `isOptimistic` and `attemptId` values.
  * Connected the new `onResetPayment` handler directly to `TicketInfo`.

### Updated
* **`components/TransactionStatusBanner.tsx`**
  * Added an optional `onRetry` prop. When present during a `failed` state, it cleanly renders an interactive "Try again" button to satisfy the retry acceptance criteria.
* **`app/components/explore/EventCheckout/PurchasedStage.tsx`**
  * Updated the post-purchase "Confirming on-chain" banner to use cohesive purple brand styling, aligning it visually with the `TransactionStatusBanner` pending state.

---

## Verification & Testing
- Run locally using `npm run dev` and initiated checkout. Verified state transitions smoothly: `Idle` ➔ `Pending (10s)` ➔ `Confirmed`/`Failed`.
- Verified the "Try again" button successfully wipes error states and re-initiates the payment loop.
- Executed `npm run build` locally to confirm zero TypeScript compilation or build-time regressions.