### PR TITLE
feat: share filtered explore links

### DIFF
--- a/app/components/explore/MainContent.tsx
+++ b/app/components/explore/MainContent.tsx
@@ -9,12 +9,20 @@ import type { EventType, Event } from "@/lib/dummyEvents/events";
 
 interface MainContentProps {
   initialEvents?: Event[];
+  initialQuery?: {
+    privacy: string | null;
+    price: string | null;
+    location: string | null;
+    date: string | null;
+    eventType: string | null;
+    sort: string | null;
+  };
 }
 
-const SORT_OPTIONS = ["Popular", "Date", "Name", "Price"];
-const PRIVACY_OPTIONS = ["Anonymous", "Verified Access", "Wallet Required"];
-const PRICE_OPTIONS = ["Free Events Only", "Paid Events Only"];
-const EVENT_TYPE_OPTIONS: EventType[] = [
+const SORT_OPTIONS = ["Popular", "Date", "Name", "Price"] as const;
+const PRIVACY_OPTIONS = ["Anonymous", "Verified Access", "Wallet Required"] as const;
+const PRICE_OPTIONS = ["Free Events Only", "Paid Events Only"] as const;
+const EVENT_TYPE_OPTIONS = [
   "Music",
   "Tech & Web3",
   "Art & Culture",
@@ -22,33 +30,50 @@ const EVENT_TYPE_OPTIONS: EventType[] = [
   "Health & Wellness",
   "Education",
   "Community",
-];
+] as const;
+
+const getOptionParam = <T extends readonly string[]>(
+  params: URLSearchParams,
+  key: string,
+  options: T
+): T[number] | null => {
+  const value = params.get(key);
+  return value && options.includes(value as T[number])
+    ? (value as T[number])
+    : null;
+};
 
 const getQueryState = (search: string) => {
   const params = new URLSearchParams(search);
 
   return {
-    privacy: params.get("privacy"),
-    price: params.get("price"),
+    privacy: getOptionParam(params, "privacy", PRIVACY_OPTIONS),
+    price: getOptionParam(params, "price", PRICE_OPTIONS),
     location: params.get("location"),
     date: params.get("date"),
-    eventType: params.get("eventType"),
-    sort: params.get("sort"),
+    eventType: getOptionParam(params, "eventType", EVENT_TYPE_OPTIONS),
+    sort: getOptionParam(params, "sort", SORT_OPTIONS),
   };
 };
 
-function MainContent({ initialEvents = [] }: MainContentProps) {
+const defaultQueryState = {
+  privacy: null,
+  price: null,
+  location: null,
+  date: null,
+  eventType: null,
+  sort: null,
+};
+
+function MainContent({ initialEvents = [], initialQuery }: MainContentProps) {
   const PAGE_SIZE = 8;
   const [events] = useState<Event[]>(initialEvents);
   const router = useRouter();
   const pathname = usePathname();
-  const privacyOptions = PRIVACY_OPTIONS;
-  const priceOptions = PRICE_OPTIONS;
-  const eventTypeOptions = EVENT_TYPE_OPTIONS;
-  const initialQueryState = useMemo(
-    () => getQueryState(typeof window !== "undefined" ? window.location.search : ""),
-    []
-  );
+  const privacyOptions = Array.from(PRIVACY_OPTIONS);
+  const priceOptions = Array.from(PRICE_OPTIONS);
+  const eventTypeOptions = Array.from(EVENT_TYPE_OPTIONS) as EventType[];
+  const initialQueryState = initialQuery ?? defaultQueryState;
   const [selectedPrivacy, setSelectedPrivacy] = useState<string | null>(
     initialQueryState.privacy
   );
@@ -140,8 +165,13 @@ function MainContent({ initialEvents = [] }: MainContentProps) {
     },
   ];
 
+  const isSortOption = (
+    value: string | null
+  ): value is (typeof SORT_OPTIONS)[number] =>
+    value !== null && (SORT_OPTIONS as readonly string[]).includes(value);
+
   const [selectedSort, setSelectedSort] = useState<string>(
-    initialQueryState.sort && SORT_OPTIONS.includes(initialQueryState.sort)
+    isSortOption(initialQueryState.sort)
       ? initialQueryState.sort
       : SORT_OPTIONS[0]
   );
@@ -347,7 +377,7 @@ function MainContent({ initialEvents = [] }: MainContentProps) {
             <CustomDropdown
               key={f.key}
               label={f.label}
-              options={f.options}
+              options={[...f.options]}
               value={f.value}
               onChange={f.setValue}
               showAllLabel={f.showAllLabel}
@@ -455,7 +485,7 @@ function MainContent({ initialEvents = [] }: MainContentProps) {
                 <div key={f.key}>
                   <CustomDropdown
                     label={f.label}
-                    options={f.options}
+                    options={[...f.options]}
                     value={
                       f.key === "privacy"
                         ? mobilePrivacy

--- a/app/components/explore/MainContent.tsx
+++ b/app/components/explore/MainContent.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useMemo, useCallback, useRef } from "react";
+import { usePathname, useRouter } from "next/navigation";
 import Card from "./card";
 import { EmptyStateIcon } from "@/public/svg/svg";
 import CustomDropdown from "./CustomDropdown";
@@ -10,15 +11,61 @@ interface MainContentProps {
   initialEvents?: Event[];
 }
 
+const SORT_OPTIONS = ["Popular", "Date", "Name", "Price"];
+const PRIVACY_OPTIONS = ["Anonymous", "Verified Access", "Wallet Required"];
+const PRICE_OPTIONS = ["Free Events Only", "Paid Events Only"];
+const EVENT_TYPE_OPTIONS: EventType[] = [
+  "Music",
+  "Tech & Web3",
+  "Art & Culture",
+  "Business",
+  "Health & Wellness",
+  "Education",
+  "Community",
+];
+
+const getQueryState = (search: string) => {
+  const params = new URLSearchParams(search);
+
+  return {
+    privacy: params.get("privacy"),
+    price: params.get("price"),
+    location: params.get("location"),
+    date: params.get("date"),
+    eventType: params.get("eventType"),
+    sort: params.get("sort"),
+  };
+};
+
 function MainContent({ initialEvents = [] }: MainContentProps) {
   const PAGE_SIZE = 8;
   const [events] = useState<Event[]>(initialEvents);
-  const [selectedPrivacy, setSelectedPrivacy] = useState<string | null>(null);
-  const [selectedPrice, setSelectedPrice] = useState<string | null>(null);
-  const [selectedLocation, setSelectedLocation] = useState<string | null>(null);
-  const [selectedDate, setSelectedDate] = useState<string | null>(null);
+  const router = useRouter();
+  const pathname = usePathname();
+  const privacyOptions = PRIVACY_OPTIONS;
+  const priceOptions = PRICE_OPTIONS;
+  const eventTypeOptions = EVENT_TYPE_OPTIONS;
+  const initialQueryState = useMemo(
+    () => getQueryState(typeof window !== "undefined" ? window.location.search : ""),
+    []
+  );
+  const [selectedPrivacy, setSelectedPrivacy] = useState<string | null>(
+    initialQueryState.privacy
+  );
+  const [selectedPrice, setSelectedPrice] = useState<string | null>(
+    initialQueryState.price
+  );
+  const [selectedLocation, setSelectedLocation] = useState<string | null>(
+    initialQueryState.location
+  );
+  const [selectedDate, setSelectedDate] = useState<string | null>(
+    initialQueryState.date
+  );
   const [selectedEventType, setSelectedEventType] = useState<EventType | null>(
-    null
+    initialQueryState.eventType &&
+      eventTypeOptions.includes(initialQueryState.eventType as EventType)
+      ? (initialQueryState.eventType as EventType)
+      : null
   );
   const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
   const [drawerOpen, setDrawerOpen] = useState(false);
@@ -35,8 +82,6 @@ function MainContent({ initialEvents = [] }: MainContentProps) {
     selectedLocation
   );
 
-  const privacyOptions = ["Anonymous", "Verified Access", "Wallet Required"];
-  const priceOptions = ["Free Events Only", "Paid Events Only"];
   const locationOptions = [
     { content: "All", onClick: () => setSelectedLocation(null) },
     ...Array.from(new Set(events.map((event) => event.location))).map(
@@ -47,15 +92,6 @@ function MainContent({ initialEvents = [] }: MainContentProps) {
     ),
   ];
   const dateOptions = ["Today", "This Week", "This Month"];
-  const eventTypeOptions: EventType[] = [
-    "Music",
-    "Tech & Web3",
-    "Art & Culture",
-    "Business",
-    "Health & Wellness",
-    "Education",
-    "Community",
-  ];
 
   const filterConfigs = [
     {
@@ -104,8 +140,73 @@ function MainContent({ initialEvents = [] }: MainContentProps) {
     },
   ];
 
-  const sortOptions = ["Popular", "Date", "Name", "Price"];
-  const [selectedSort, setSelectedSort] = useState<string>(sortOptions[0]);
+  const [selectedSort, setSelectedSort] = useState<string>(
+    initialQueryState.sort && SORT_OPTIONS.includes(initialQueryState.sort)
+      ? initialQueryState.sort
+      : SORT_OPTIONS[0]
+  );
+  useEffect(() => {
+    const syncFiltersFromLocation = () => {
+      const queryState = getQueryState(window.location.search);
+
+      setSelectedPrivacy(queryState.privacy ?? null);
+      setSelectedPrice(queryState.price ?? null);
+      setSelectedLocation(queryState.location ?? null);
+      setSelectedDate(queryState.date ?? null);
+      setSelectedEventType(
+        queryState.eventType &&
+          eventTypeOptions.includes(queryState.eventType as EventType)
+          ? (queryState.eventType as EventType)
+          : null
+      );
+      setSelectedSort(
+        queryState.sort && SORT_OPTIONS.includes(queryState.sort)
+          ? queryState.sort
+          : SORT_OPTIONS[0]
+      );
+    };
+
+    syncFiltersFromLocation();
+    window.addEventListener("popstate", syncFiltersFromLocation);
+
+    return () => window.removeEventListener("popstate", syncFiltersFromLocation);
+  }, [eventTypeOptions]);
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+
+    const setParam = (key: string, value: string | null) => {
+      if (!value) {
+        params.delete(key);
+      } else {
+        params.set(key, value);
+      }
+    };
+
+    setParam("privacy", selectedPrivacy);
+    setParam("price", selectedPrice);
+    setParam("location", selectedLocation);
+    setParam("date", selectedDate);
+    setParam("eventType", selectedEventType);
+    setParam("sort", selectedSort !== SORT_OPTIONS[0] ? selectedSort : null);
+
+    const nextQuery = params.toString();
+    const nextUrl = nextQuery ? `${pathname}?${nextQuery}` : pathname;
+    const currentUrl = `${pathname}${window.location.search}`;
+
+    if (currentUrl !== nextUrl) {
+      router.replace(nextUrl, { scroll: false });
+    }
+  }, [pathname, router, selectedDate, selectedEventType, selectedLocation, selectedPrice, selectedPrivacy, selectedSort]);
+
+  useEffect(() => {
+    setMobilePrivacy(selectedPrivacy);
+    setMobilePrice(selectedPrice);
+    setMobileDate(selectedDate);
+    setMobileEventType(selectedEventType);
+    setMobileLocation(selectedLocation);
+  }, [selectedDate, selectedEventType, selectedLocation, selectedPrice, selectedPrivacy]);
+
   const filteredEvents = useMemo(
     () =>
       events.filter((event) => {

--- a/app/explore/page.tsx
+++ b/app/explore/page.tsx
@@ -10,8 +10,24 @@ export const metadata: Metadata = {
   keywords: "events, explore, discover, community",
 };
 
+const SORT_OPTIONS = ["Popular", "Date", "Name", "Price"] as const;
+const PRIVACY_OPTIONS = ["Anonymous", "Verified Access", "Wallet Required"] as const;
+const PRICE_OPTIONS = ["Free Events Only", "Paid Events Only"] as const;
+const DATE_OPTIONS = ["Today", "This Week", "This Month"] as const;
+const EVENT_TYPE_OPTIONS = [
+  "Music",
+  "Tech & Web3",
+  "Art & Culture",
+  "Business",
+  "Health & Wellness",
+  "Education",
+  "Community",
+] as const;
+
+type SearchParamsRecord = Record<string, string | string[] | undefined>;
+
 const extractSearchParam = (
-  searchParams: Record<string, string | string[] | undefined>,
+  searchParams: SearchParamsRecord,
   key: string
 ) => {
   const value = searchParams[key];
@@ -19,17 +35,33 @@ const extractSearchParam = (
   return value ?? null;
 };
 
+const getOptionParam = <T extends readonly string[]>(
+  searchParams: SearchParamsRecord,
+  key: string,
+  options: T
+): T[number] | null => {
+  const value = extractSearchParam(searchParams, key);
+  return value && options.includes(value as T[number])
+    ? (value as T[number])
+    : null;
+};
+
 export default async function ExplorePage({ searchParams }: any) {
+  const resolvedSearchParams = await searchParams;
   // Server-side data fetching for SSR
   const events = await getAllPublicEvents();
 
   const initialQuery = {
-    privacy: extractSearchParam(searchParams, "privacy"),
-    price: extractSearchParam(searchParams, "price"),
-    location: extractSearchParam(searchParams, "location"),
-    date: extractSearchParam(searchParams, "date"),
-    eventType: extractSearchParam(searchParams, "eventType"),
-    sort: extractSearchParam(searchParams, "sort"),
+    privacy: getOptionParam(resolvedSearchParams, "privacy", PRIVACY_OPTIONS),
+    price: getOptionParam(resolvedSearchParams, "price", PRICE_OPTIONS),
+    location: extractSearchParam(resolvedSearchParams, "location"),
+    date: getOptionParam(resolvedSearchParams, "date", DATE_OPTIONS),
+    eventType: getOptionParam(
+      resolvedSearchParams,
+      "eventType",
+      EVENT_TYPE_OPTIONS
+    ),
+    sort: getOptionParam(resolvedSearchParams, "sort", SORT_OPTIONS),
   };
 
   return (

--- a/app/explore/page.tsx
+++ b/app/explore/page.tsx
@@ -10,13 +10,31 @@ export const metadata: Metadata = {
   keywords: "events, explore, discover, community",
 };
 
-export default async function ExplorePage() {
+const extractSearchParam = (
+  searchParams: Record<string, string | string[] | undefined>,
+  key: string
+) => {
+  const value = searchParams[key];
+  if (Array.isArray(value)) return value[0] ?? null;
+  return value ?? null;
+};
+
+export default async function ExplorePage({ searchParams }: any) {
   // Server-side data fetching for SSR
   const events = await getAllPublicEvents();
 
+  const initialQuery = {
+    privacy: extractSearchParam(searchParams, "privacy"),
+    price: extractSearchParam(searchParams, "price"),
+    location: extractSearchParam(searchParams, "location"),
+    date: extractSearchParam(searchParams, "date"),
+    eventType: extractSearchParam(searchParams, "eventType"),
+    sort: extractSearchParam(searchParams, "sort"),
+  };
+
   return (
     <div className="bg-white dark:bg-[#0D0D0D] min-h-screen">
-      <MainContent initialEvents={events} />
+      <MainContent initialEvents={events} initialQuery={initialQuery} />
     </div>
   );
 }


### PR DESCRIPTION
Allow users to share links that preserve the current explore page filters.
When filters are applied, the URL updates so friends can open the same filtered view.
This improves discoverability and makes filtered event links shareable across the app.
Closes #122 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Explore filters (privacy, price, location, date, event type) and sorting now initialize from URL query parameters, so shared/bookmarked links preserve the selected view.
  * Filter and sort changes now automatically update the URL for easier navigation and sharing.
* **Bug Fixes**
  * Back/forward navigation restores the prior filter and sort selections correctly.
  * Invalid or unsupported query values are safely ignored, preventing broken states.
  * Mobile filter UI stays in sync with the currently selected filters and sort.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->