### PR TITLE
chores: fixed duplicate cta content in event card

### DIFF
--- a/app/components/EventCard.tsx
+++ b/app/components/EventCard.tsx
@@ -135,7 +135,6 @@ export default function EventCard({
               className="flex items-center gap-1 text-[14px] font-semibold [color:var(--color-text-detail)] dark:[color:var(--color-text-main-dark)] cursor-pointer transition-all duration-200 hover:gap-2"
             >
               Get Ticket
-              Get Ticket
               <Image
                 src="/assets/icons/arrowRightIcon.svg"
                 alt=""


### PR DESCRIPTION
Closes #153

# fix: remove duplicate "Get Ticket" CTA text on event card

## Problem

The event card rendered the CTA label **"Get Ticket" twice**, causing the text to wrap and collide with the price block. The result was a visually broken card footer whenever an event had a price and a valid link target.

The duplication lived in `app/components/EventCard.tsx`, inside the `<Link>` branch of the CTA — the branch used when an event has an `eventId` and is **not** sold out:

```tsx
<Link href={exploreHref} className="...">
  Get Ticket
  Get Ticket        {/* <-- duplicated */}
  <Image src="/assets/icons/arrowRightIcon.svg" ... />
</Link>
```

Because the CTA is a three-way conditional, only this one path was affected:

| Branch | Condition | Status before fix |
| --- | --- | --- |
| `<Link>` | `eventId && !isSoldOut` | ❌ duplicated label |
| `<span>` | `eventId && isSoldOut` | ✅ correct ("Sold out") |
| `<button>` | no `eventId` (fallback) | ✅ correct |

This is why the bug only surfaced on real, purchasable events and not on the default/placeholder cards.

## Change

Removed the redundant text node. Single-line diff:

```diff
--- a/app/components/EventCard.tsx
+++ b/app/components/EventCard.tsx
@@ -134,7 +134,6 @@ export default function EventCard({
               href={exploreHref}
               className="flex items-center gap-1 text-[14px] font-semibold [color:var(--color-text-detail)] dark:[color:var(--color-text-main-dark)] cursor-pointer transition-all duration-200 hover:gap-2"
             >
-              Get Ticket
               Get Ticket
               <Image
                 src="/assets/icons/arrowRightIcon.svg"
```

No markup, styling, layout, or logic was altered — the fix is purely the removal of the duplicated string, so the existing `flex`/`gap` footer layout renders as originally designed.

## Files changed

- `app/components/EventCard.tsx` — removed duplicate CTA text (1 deletion)

## Verification

- ✅ `npm run build` completes successfully; all routes compile with no new errors or warnings.
- ✅ `grep -rn "Get Ticket" app/ components/` — no remaining duplicates. Other matches are in unrelated components (`app/newComponents/trending-events.tsx`, `app/components/ZikcetTrending.tsx`, `app/components/explore/card.tsx`) or in the mutually-exclusive sold-out / fallback branches of this same component, all of which were already correct.
- ✅ `git status` shows **only** `app/components/EventCard.tsx` modified. `package-lock.json` and all other files are untouched.

## Acceptance criteria

- [x] Card no longer shows duplicate CTA text content
- [x] No other changes committed apart from the current task
- [x] Follows existing code style (no formatting churn — a pure deletion)
- [x] PR builds properly; deploy preview available for maintainer review

## Note for reviewer (out of scope — not changed here)

The `<Link>` branch is missing the `aria-label={`Get tickets for ${title}`}` that both the `<button>` fallback in this same file and `app/components/explore/card.tsx` already provide. Screen reader users get the bare link text without event context on this path. Deliberately left alone to keep this PR scoped to the reported bug — happy to open a follow-up issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted spacing and alignment in the “Get Ticket” call-to-action for available events.
  * The ticket link label and arrow icon remain unchanged in functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->