### PR TITLE
feat: implement unified failure-state UX system for wallet/chain errors

### DIFF
--- a/app/api/payments/reconcile/route.ts
+++ b/app/api/payments/reconcile/route.ts
@@ -15,6 +15,15 @@ type TicketRecord = {
 
 const processedAttempts = new Map<string, TicketRecord>();
 
+/**
+ * Finalizes a ticket purchase after an on-chain payment (or free registration)
+ * has been confirmed. Idempotent by `attemptId`: replaying the same attempt
+ * returns the previously issued ticket instead of creating a duplicate, so a
+ * failed-then-retried reconcile can never issue two tickets or double-charge.
+ *
+ * Responds 400 for malformed/missing fields, 409 when the attempt isn't
+ * confirmed yet, and 200 with `{ ticketId, deduplicated }` on success.
+ */
 export async function POST(request: Request) {
   let body: ReconcileRequest;
 

--- a/app/api/payments/reconcile/route.ts
+++ b/app/api/payments/reconcile/route.ts
@@ -37,7 +37,10 @@ export async function POST(request: Request) {
     );
   }
 
-  if (!body.isConfirmed || !body.isPaid) {
+  // `isPaid: false` is a legitimate, expected value for free/anonymous
+  // events — only `isConfirmed` indicates the attempt isn't ready to
+  // reconcile yet.
+  if (!body.isConfirmed) {
     return NextResponse.json(
       { ok: false, error: "Payment is not yet fully confirmed." },
       { status: 409 },

--- a/app/api/payments/reconcile/route.ts
+++ b/app/api/payments/reconcile/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { dummyEvents } from "@/lib/dummyEvents/events";
 
 type ReconcileRequest = {
   attemptId?: string;
@@ -21,8 +22,12 @@ const processedAttempts = new Map<string, TicketRecord>();
  * returns the previously issued ticket instead of creating a duplicate, so a
  * failed-then-retried reconcile can never issue two tickets or double-charge.
  *
- * Responds 400 for malformed/missing fields, 409 when the attempt isn't
- * confirmed yet, and 200 with `{ ticketId, deduplicated }` on success.
+ * Free-vs-paid eligibility is derived from server-side event data rather than
+ * the client's `isPaid` flag, so a paid event can't be reconciled for free.
+ *
+ * Responds 400 for malformed/missing fields, 404 for an unknown event, 409
+ * when the attempt isn't confirmed, 402 when a paid event lacks payment, and
+ * 200 with `{ ticketId, deduplicated }` on success.
  */
 export async function POST(request: Request) {
   let body: ReconcileRequest;
@@ -46,13 +51,33 @@ export async function POST(request: Request) {
     );
   }
 
-  // `isPaid: false` is a legitimate, expected value for free/anonymous
-  // events — only `isConfirmed` indicates the attempt isn't ready to
-  // reconcile yet.
   if (!body.isConfirmed) {
     return NextResponse.json(
       { ok: false, error: "Payment is not yet fully confirmed." },
       { status: 409 },
+    );
+  }
+
+  // Derive free/paid eligibility from server-side event data, not from the
+  // client-supplied `isPaid` flag. This stops a caller from reconciling a paid
+  // event for free by simply sending `isPaid: false`.
+  //
+  // NOTE: `dummyEvents` stands in for a real event store here. For a paid event
+  // this still trusts that the client-side wallet flow ran; production must
+  // replace this with verification of a settled on-chain payment tied to
+  // `attemptId` before issuing the ticket.
+  const event = dummyEvents.find((e) => e.id === eventId);
+  if (!event) {
+    return NextResponse.json(
+      { ok: false, error: "Unknown event." },
+      { status: 404 },
+    );
+  }
+
+  if (event.isPaid && !body.isPaid) {
+    return NextResponse.json(
+      { ok: false, error: "This event requires a completed payment." },
+      { status: 402 },
     );
   }
 

--- a/app/components/explore/EventCheckout/PurchasedStage.tsx
+++ b/app/components/explore/EventCheckout/PurchasedStage.tsx
@@ -8,6 +8,11 @@ interface PurchasedStageProps {
   onCancelRegistration?: () => void;
 }
 
+/**
+ * Success screen shown once a ticket purchase is fully reconciled — the real
+ * "you're in" confirmation, as opposed to the in-flight status shown by the
+ * checkout banner. Offers access-code and cancel-registration actions.
+ */
 export const PurchasedStage: FC<PurchasedStageProps> = ({
   onViewAccessCode,
   onCancelRegistration,

--- a/app/components/explore/EventCheckout/PurchasedStage.tsx
+++ b/app/components/explore/EventCheckout/PurchasedStage.tsx
@@ -2,30 +2,18 @@
 
 import { FC } from "react";
 import Image from "next/image";
-import { Loader2 } from "lucide-react";
 
 interface PurchasedStageProps {
-  isConfirming?: boolean;
   onViewAccessCode?: () => void;
   onCancelRegistration?: () => void;
 }
 
 export const PurchasedStage: FC<PurchasedStageProps> = ({
-  isConfirming = false,
   onViewAccessCode,
   onCancelRegistration,
 }) => {
   return (
     <div className="p-8 border border-[#E9E9E9] rounded-2xl dark:border-[#232323] w-full bg-white dark:bg-[#0A0A0A] shadow-[0_4px_20px_rgba(0,0,0,0.03)] font-work-sans">
-      {isConfirming && (
-        <div className="flex items-center gap-2 mb-5 bg-[#F5EEFF] dark:bg-[#1C0F2E] border border-[#D4ADFC] dark:border-[#4A1F7A] text-[#6917AF] dark:text-[#D7B5F5] py-3 px-4 rounded-lg">
-          <Loader2 className="animate-spin shrink-0" size={16} />
-          <p className="text-xs font-medium">
-            Confirming on-chain&hellip; your ticket is reserved.
-          </p>
-        </div>
-      )}
-
       <div className="flex justify-between items-center mb-5">
         <h2 className="text-[32px] font-bold text-[#1F1F1F] dark:text-white">
           You&apos;re In!
@@ -79,7 +67,6 @@ export const PurchasedStage: FC<PurchasedStageProps> = ({
       <div className="flex gap-5">
         <button
           onClick={onViewAccessCode}
-          disabled={isConfirming}
           className="flex-1 py-4 bg-[#6917AF] text-white rounded-full flex items-center justify-center gap-3 hover:bg-[#5A1396] transition-all shadow-md active:scale-[0.98] disabled:opacity-60 disabled:cursor-not-allowed"
         >
           <Image src="/qr-code-01.png" alt="QR Code" width={24} height={24} />
@@ -88,7 +75,6 @@ export const PurchasedStage: FC<PurchasedStageProps> = ({
 
         <button
           onClick={onCancelRegistration}
-          disabled={isConfirming}
           className="flex-1 py-4 border-2 border-[#6917AF] text-[#6917AF] dark:text-[#E0E0E0] rounded-full font-bold flex items-center justify-center gap-3 hover:bg-[#6917AF]/5 transition-all outline-none active:scale-[0.98] disabled:opacity-60 disabled:cursor-not-allowed"
         >
           <Image

--- a/app/components/explore/EventCheckout/TicketInfo.tsx
+++ b/app/components/explore/EventCheckout/TicketInfo.tsx
@@ -19,7 +19,7 @@ import { useUserSessionSync } from "@/lib/user-session-sync";
 import { useCooldown } from "@/hooks/useCooldown";
 import { CooldownMessage } from "@/app/components/AntiSpam/CooldownMessage";
 import { TransactionStatusBanner, type BannerStatus } from "@/components/TransactionStatusBanner";
-import { useTransactionStatus } from "@/hooks/useTransactionStatus";
+import { useTransactionStatus, type TransactionStatus } from "@/hooks/useTransactionStatus";
 
 type PaymentStatus = "idle" | "processing" | "failed";
 
@@ -35,6 +35,31 @@ interface TicketInfoProps {
     isPaid: boolean;
   }) => Promise<{ ok: boolean; error?: string }> | { ok: boolean; error?: string };
   onResetPayment?: () => void;
+}
+
+/**
+ * Single derived status driving the one shared banner, in priority order, so
+ * a chain success and a reconcile failure can never render two contradictory
+ * messages at once.
+ */
+function getBannerStatus(params: {
+  walletError: string | null;
+  chainStatus: TransactionStatus;
+  hasPaymentFailed: boolean;
+  isReconciling: boolean;
+}): BannerStatus {
+  const { walletError, chainStatus, hasPaymentFailed, isReconciling } = params;
+
+  if (walletError) return "wallet_error";
+  if (chainStatus === "failed") return "failed";
+  if (chainStatus === "confirmed" && hasPaymentFailed) return "reconcile_failed";
+  if (chainStatus === "confirmed" && isReconciling) return "reconciling";
+  if (chainStatus === "stalled") return "stalled";
+  if (chainStatus === "pending") return "pending";
+  if (chainStatus === "confirmed") return "confirmed";
+  // Pre-flight failure (e.g. sold out) — no tx was ever attempted.
+  if (hasPaymentFailed) return "failed";
+  return "idle";
 }
 
 export const TicketInfo: FC<TicketInfoProps> = ({
@@ -110,12 +135,12 @@ export const TicketInfo: FC<TicketInfoProps> = ({
       return;
     }
 
+    if (isSoldOut) return;
+
     startCooldown();
 
     setWalletState({ isLoading: true, error: null });
     resetChainTracking();
-
-    if (isSoldOut || isProcessingPayment) return;
 
     try {
       if (isPaid) {
@@ -182,7 +207,7 @@ export const TicketInfo: FC<TicketInfoProps> = ({
       return (
         <>
           <WifiOff size={20} />
-          Checking connection…
+          Connection issue…
         </>
       );
 
@@ -240,26 +265,12 @@ export const TicketInfo: FC<TicketInfoProps> = ({
     );
   };
 
-  // Single derived status drives the one shared banner below, so a chain
-  // success and a reconcile failure can never render two contradictory
-  // messages at once.
-  const bannerStatus: BannerStatus = walletState.error
-    ? "wallet_error"
-    : chainStatus === "failed"
-      ? "failed"
-      : chainStatus === "confirmed" && hasPaymentFailed
-        ? "reconcile_failed"
-        : chainStatus === "confirmed" && isProcessingPayment
-          ? "reconciling"
-          : chainStatus === "stalled"
-            ? "stalled"
-            : chainStatus === "pending"
-              ? "pending"
-              : chainStatus === "confirmed"
-                ? "confirmed"
-                : hasPaymentFailed
-                  ? "failed" // pre-flight failure (e.g. sold out) — no tx was ever attempted
-                  : "idle";
+  const bannerStatus = getBannerStatus({
+    walletError: walletState.error,
+    chainStatus,
+    hasPaymentFailed,
+    isReconciling: isProcessingPayment,
+  });
 
   const bannerError =
     bannerStatus === "wallet_error"
@@ -270,7 +281,7 @@ export const TicketInfo: FC<TicketInfoProps> = ({
 
   const bannerRetry =
     bannerStatus === "wallet_error"
-      ? handlePrimaryClick
+      ? (isOnCooldown ? undefined : handlePrimaryClick)
       : bannerStatus === "reconcile_failed"
         ? () => void onStatusChange?.({ isConfirmed: true, isPaid })
         : bannerStatus === "failed"
@@ -394,54 +405,57 @@ export const TicketInfo: FC<TicketInfoProps> = ({
               ))}
             </div>
           </div>
-
-          {/* Unified failure/status banner — covers wallet errors, chain
-              delays, stalled connections, on-chain failures, and partial
-              (on-chain-ok-but-not-reconciled) confirmations in one place. */}
-          <TransactionStatusBanner
-            status={bannerStatus}
-            txHash={chainTxHash}
-            error={bannerError}
-            retryLabel={bannerStatus === "reconcile_failed" ? "Retry Confirmation" : undefined}
-            onRetry={bannerRetry}
-            onCheckConnection={bannerStatus === "stalled" ? checkConnection : undefined}
-          />
-
-          {/* Cooldown message */}
-          <CooldownMessage remainingSeconds={remainingSeconds} />
-
-          <div className="bg-[#F2FFF2] dark:bg-[#131313] dark:text-[#0BD330] text-[#0ABA2A] py-3 px-5 gap-4 flex">
-            <DangerIcon />
-            <p className="text-xs font-medium">Secure & Instant Payment</p>
-          </div>
-
-          <div>
-            <button
-              type="button"
-              disabled={isSoldOut || isProcessingPayment || walletState.isLoading || isButtonDisabled}
-              onClick={handlePrimaryClick}
-              onMouseEnter={isSoldOut ? undefined : preloadWalletSDK}
-              onFocus={isSoldOut ? undefined : preloadWalletSDK}
-              className={
-                isSoldOut
-                  ? "py-4 px-6 flex w-full items-center justify-center font-bold rounded-full gap-3 duration-200 ease-in-out transition bg-[#E4E5E6] text-[#98A2B3] cursor-not-allowed dark:bg-[#232323] dark:text-[#667085]"
-                  : `py-4 px-6 bg-[#6917AF] text-[#FCFDFD] flex w-full items-center justify-center font-bold rounded-full gap-3 duration-200 ease-in-out transition dark:bg-[#751AC6] dark:text-[#0F0F0F] dark:hover:bg-[#751AC6]/95 disabled:opacity-60 disabled:cursor-not-allowed ${!(isProcessingPayment || walletState.isLoading)
-                    ? "cursor-pointer hover:bg-[#6917AF]/95"
-                    : ""
-                    }`
-              }
-            >
-              {isSoldOut ? (
-                <>
-                  <PasswordProtectedShield />
-                  <span>Sold out</span>
-                </>
-              ) : (
-                <>{buttonLabel()}</>
-              )}
-            </button>
-          </div>
         </fieldset>
+
+        {/* Unified failure/status banner — covers wallet errors, chain
+            delays, stalled connections, on-chain failures, and partial
+            (on-chain-ok-but-not-reconciled) confirmations in one place.
+            Kept outside the fieldset above: its retry/check-connection
+            actions must stay usable even if the event sells out while a
+            payment the user already made is still being reconciled. */}
+        <TransactionStatusBanner
+          status={bannerStatus}
+          txHash={chainTxHash}
+          error={bannerError}
+          retryLabel={bannerStatus === "reconcile_failed" ? "Retry Confirmation" : undefined}
+          onRetry={bannerRetry}
+          onCheckConnection={bannerStatus === "stalled" ? checkConnection : undefined}
+        />
+
+        {/* Cooldown message */}
+        <CooldownMessage remainingSeconds={remainingSeconds} />
+
+        <div className="bg-[#F2FFF2] dark:bg-[#131313] dark:text-[#0BD330] text-[#0ABA2A] py-3 px-5 gap-4 flex">
+          <DangerIcon />
+          <p className="text-xs font-medium">Secure & Instant Payment</p>
+        </div>
+
+        <div>
+          <button
+            type="button"
+            disabled={isSoldOut || isProcessingPayment || walletState.isLoading || isButtonDisabled}
+            onClick={handlePrimaryClick}
+            onMouseEnter={isSoldOut ? undefined : preloadWalletSDK}
+            onFocus={isSoldOut ? undefined : preloadWalletSDK}
+            className={
+              isSoldOut
+                ? "py-4 px-6 flex w-full items-center justify-center font-bold rounded-full gap-3 duration-200 ease-in-out transition bg-[#E4E5E6] text-[#98A2B3] cursor-not-allowed dark:bg-[#232323] dark:text-[#667085]"
+                : `py-4 px-6 bg-[#6917AF] text-[#FCFDFD] flex w-full items-center justify-center font-bold rounded-full gap-3 duration-200 ease-in-out transition dark:bg-[#751AC6] dark:text-[#0F0F0F] dark:hover:bg-[#751AC6]/95 disabled:opacity-60 disabled:cursor-not-allowed ${!(isProcessingPayment || walletState.isLoading)
+                  ? "cursor-pointer hover:bg-[#6917AF]/95"
+                  : ""
+                  }`
+            }
+          >
+            {isSoldOut ? (
+              <>
+                <PasswordProtectedShield />
+                <span>Sold out</span>
+              </>
+            ) : (
+              <>{buttonLabel()}</>
+            )}
+          </button>
+        </div>
       </form>
     </div>
   );

--- a/app/components/explore/EventCheckout/TicketInfo.tsx
+++ b/app/components/explore/EventCheckout/TicketInfo.tsx
@@ -64,6 +64,12 @@ function getBannerStatus(params: {
   return "idle";
 }
 
+/**
+ * Ticket purchase panel for an event. Drives the paid (wallet + on-chain
+ * polling) and free (anonymous) flows, coordinates reconciliation via
+ * `onStatusChange`, and renders a single derived {@link TransactionStatusBanner}
+ * so wallet, chain, and reconcile states never contradict each other.
+ */
 export const TicketInfo: FC<TicketInfoProps> = ({
   eventId,
   ticketTypes,

--- a/app/components/explore/EventCheckout/TicketInfo.tsx
+++ b/app/components/explore/EventCheckout/TicketInfo.tsx
@@ -46,17 +46,19 @@ function getBannerStatus(params: {
   walletError: string | null;
   chainStatus: TransactionStatus;
   hasPaymentFailed: boolean;
-  isReconciling: boolean;
 }): BannerStatus {
-  const { walletError, chainStatus, hasPaymentFailed, isReconciling } = params;
+  const { walletError, chainStatus, hasPaymentFailed } = params;
 
   if (walletError) return "wallet_error";
   if (chainStatus === "failed") return "failed";
   if (chainStatus === "confirmed" && hasPaymentFailed) return "reconcile_failed";
-  if (chainStatus === "confirmed" && isReconciling) return "reconciling";
+  // Any on-chain confirmation still in checkout means we're finalizing (or
+  // about to). Never show the green "Ticket confirmed!" success here — that
+  // would flash between poll confirm and paymentStatus flipping to
+  // "processing", and the real success UI is PurchasedStage.
+  if (chainStatus === "confirmed") return "reconciling";
   if (chainStatus === "stalled") return "stalled";
   if (chainStatus === "pending") return "pending";
-  if (chainStatus === "confirmed") return "confirmed";
   // Pre-flight failure (e.g. sold out) — no tx was ever attempted.
   if (hasPaymentFailed) return "failed";
   return "idle";
@@ -149,7 +151,13 @@ export const TicketInfo: FC<TicketInfoProps> = ({
         setWalletState({ isLoading: false, error: null });
         startTracking(txHash);
       } else {
-        await onStatusChange?.({ isConfirmed: true, isPaid: false });
+        const result = await onStatusChange?.({ isConfirmed: true, isPaid: false });
+        if (result && !result.ok) {
+          // Parent owns paymentError / failed banner — don't pretend anonymous
+          // mode succeeded when reconcile rejected the attempt.
+          setWalletState({ isLoading: false, error: null });
+          return;
+        }
         setAnonymousBrowsing(true);
         setWalletState({ isLoading: false, error: null });
       }
@@ -269,7 +277,6 @@ export const TicketInfo: FC<TicketInfoProps> = ({
     walletError: walletState.error,
     chainStatus,
     hasPaymentFailed,
-    isReconciling: isProcessingPayment,
   });
 
   const bannerError =

--- a/app/components/explore/EventCheckout/TicketInfo.tsx
+++ b/app/components/explore/EventCheckout/TicketInfo.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { FC, useState, useEffect, useRef, useCallback } from "react";
-import { Check, Loader2, CheckCircle2 } from "lucide-react";
+import { FC, useState } from "react";
+import { Check, Loader2, CheckCircle2, WifiOff } from "lucide-react";
 import { useSimulatedAvailability } from "@/lib/hooks/useSimulatedAvailability";
 import {
   DangerIcon,
@@ -18,17 +18,10 @@ import { loadWalletSDK, preloadWalletSDK, WalletLoadState } from "@/lib/walletSd
 import { useUserSessionSync } from "@/lib/user-session-sync";
 import { useCooldown } from "@/hooks/useCooldown";
 import { CooldownMessage } from "@/app/components/AntiSpam/CooldownMessage";
-import { TransactionStatusBanner } from "@/components/TransactionStatusBanner";
-import type { TransactionStatus } from "@/hooks/useTransactionStatus";
+import { TransactionStatusBanner, type BannerStatus } from "@/components/TransactionStatusBanner";
+import { useTransactionStatus } from "@/hooks/useTransactionStatus";
 
 type PaymentStatus = "idle" | "processing" | "failed";
-
-interface TxState {
-  status: TransactionStatus;
-  txHash: string | null;
-  error: string | null;
-  attempts: number;
-}
 
 interface TicketInfoProps {
   eventId: string;
@@ -42,17 +35,6 @@ interface TicketInfoProps {
     isPaid: boolean;
   }) => Promise<{ ok: boolean; error?: string }> | { ok: boolean; error?: string };
   onResetPayment?: () => void;
-}
-
-const POLL_INTERVAL_MS = 3000;
-const MAX_POLL_ATTEMPTS = 20;
-
-async function fetchTxStatus(
-  txHash: string
-): Promise<{ status: TransactionStatus; error?: string }> {
-  const res = await fetch(`/api/transactions/${txHash}/status`);
-  if (!res.ok) throw new Error(`HTTP ${res.status}`);
-  return res.json();
 }
 
 export const TicketInfo: FC<TicketInfoProps> = ({
@@ -81,20 +63,23 @@ export const TicketInfo: FC<TicketInfoProps> = ({
     error: null,
   });
 
-  const [txState, setTxState] = useState<TxState>({
-    status: "idle",
-    txHash: null,
-    error: null,
-    attempts: 0,
+  // Chain-level polling lives in the shared hook; reconciliation (the backend
+  // finalize step) is owned by the parent (onStatusChange) and layered on top
+  // via paymentStatus/paymentError below — see `bannerStatus`.
+  const {
+    status: chainStatus,
+    txHash: chainTxHash,
+    error: chainError,
+    startTracking,
+    reset: resetChainTracking,
+    checkConnection,
+  } = useTransactionStatus({
+    onConfirmed: () => {
+      void onStatusChange?.({ isConfirmed: true, isPaid });
+    },
   });
 
   const { isOnCooldown, remainingSeconds, startCooldown } = useCooldown({ duration: 8 });
-
-  const intervalRef = useRef<NodeJS.Timeout | null>(null);
-
-  const stopPolling = () => {
-    if (intervalRef.current) clearInterval(intervalRef.current);
-  };
 
   const decrementQuantity = () => {
     if (quantity > 1) {
@@ -114,72 +99,21 @@ export const TicketInfo: FC<TicketInfoProps> = ({
   // which we handle safely by checking inside the handlers and on render.
   const clampedQuantity = liveSlotsLeft > 0 ? Math.min(quantity, liveSlotsLeft) : quantity;
 
-  const poll = async (txHash: string) => {
-    try {
-      const result = await fetchTxStatus(txHash);
-
-      setTxState((s) => {
-        const nextAttempts = s.attempts + 1;
-
-        if (nextAttempts >= MAX_POLL_ATTEMPTS && result.status === "pending") {
-          stopPolling();
-          return {
-            ...s,
-            status: "failed" as TransactionStatus,
-            error: "Transaction is taking longer than expected. Please check your wallet and try again.",
-            attempts: nextAttempts,
-          };
-        }
-
-        return {
-          ...s,
-          status: result.status,
-          error: result.error ?? null,
-          attempts: nextAttempts,
-        };
-      });
-
-      if (result.status === "confirmed") {
-        stopPolling();
-        await onStatusChange?.({
-          isConfirmed: true,
-          isPaid,
-        });
-      } else if (result.status === "failed") {
-        stopPolling();
-      }
-    } catch {
-      setTxState((s) => {
-        const nextAttempts = s.attempts + 1;
-        if (nextAttempts >= MAX_POLL_ATTEMPTS) {
-          stopPolling();
-          return {
-            ...s,
-            status: "failed" as TransactionStatus,
-            error: "Unable to verify transaction. Please check your wallet and try again.",
-            attempts: nextAttempts,
-          };
-        }
-        return { ...s, attempts: nextAttempts };
-      });
-    }
-  };
-
-  const startTracking = (txHash: string) => {
-    setTxState({ status: "pending", txHash, error: null, attempts: 0 });
-    poll(txHash);
-    intervalRef.current = setInterval(() => poll(txHash), POLL_INTERVAL_MS);
-  };
-
-  useEffect(() => () => stopPolling(), []);
-
   const handlePrimaryClick = async () => {
-    if (isProcessingPayment || txState.status === "pending" || isOnCooldown) return;
+    if (isProcessingPayment || chainStatus === "pending" || chainStatus === "stalled" || isOnCooldown) return;
+
+    // The on-chain payment already succeeded and only the backend reconcile
+    // step failed — retry reconciliation directly. Do NOT re-trigger a new
+    // wallet signature here, or the user could end up paying twice.
+    if (hasPaymentFailed && chainStatus === "confirmed") {
+      void onStatusChange?.({ isConfirmed: true, isPaid });
+      return;
+    }
 
     startCooldown();
 
     setWalletState({ isLoading: true, error: null });
-    setTxState({ status: "idle", txHash: null, error: null, attempts: 0 });
+    resetChainTracking();
 
     if (isSoldOut || isProcessingPayment) return;
 
@@ -205,18 +139,18 @@ export const TicketInfo: FC<TicketInfoProps> = ({
     }
   };
 
-  const handleRetry = useCallback(() => {
-    stopPolling();
-    setTxState({ status: "idle", txHash: null, error: null, attempts: 0 });
+  const handleRetry = () => {
+    resetChainTracking();
     setWalletState({ isLoading: false, error: null });
     onResetPayment?.();
-  }, [onResetPayment]);
+  };
 
   const isButtonDisabled =
     walletState.isLoading ||
     isProcessingPayment ||
-    txState.status === "pending" ||
-    txState.status === "confirmed" ||
+    chainStatus === "pending" ||
+    chainStatus === "stalled" ||
+    (chainStatus === "confirmed" && paymentStatus !== "failed") ||
     isOnCooldown;
 
   const buttonLabel = () => {
@@ -236,7 +170,7 @@ export const TicketInfo: FC<TicketInfoProps> = ({
         </>
       );
 
-    if (txState.status === "pending")
+    if (chainStatus === "pending")
       return (
         <>
           <Loader2 className="animate-spin" size={20} />
@@ -244,11 +178,35 @@ export const TicketInfo: FC<TicketInfoProps> = ({
         </>
       );
 
-    if (txState.status === "confirmed")
+    if (chainStatus === "stalled")
+      return (
+        <>
+          <WifiOff size={20} />
+          Checking connection…
+        </>
+      );
+
+    if (chainStatus === "confirmed" && hasPaymentFailed)
+      return (
+        <>
+          <PasswordProtectedShield />
+          Retry Confirmation
+        </>
+      );
+
+    if (chainStatus === "confirmed")
       return (
         <>
           <CheckCircle2 size={20} />
           Ticket Confirmed
+        </>
+      );
+
+    if (chainStatus === "failed")
+      return (
+        <>
+          <PasswordProtectedShield />
+          Retry Payment
         </>
       );
 
@@ -281,6 +239,43 @@ export const TicketInfo: FC<TicketInfoProps> = ({
       </>
     );
   };
+
+  // Single derived status drives the one shared banner below, so a chain
+  // success and a reconcile failure can never render two contradictory
+  // messages at once.
+  const bannerStatus: BannerStatus = walletState.error
+    ? "wallet_error"
+    : chainStatus === "failed"
+      ? "failed"
+      : chainStatus === "confirmed" && hasPaymentFailed
+        ? "reconcile_failed"
+        : chainStatus === "confirmed" && isProcessingPayment
+          ? "reconciling"
+          : chainStatus === "stalled"
+            ? "stalled"
+            : chainStatus === "pending"
+              ? "pending"
+              : chainStatus === "confirmed"
+                ? "confirmed"
+                : hasPaymentFailed
+                  ? "failed" // pre-flight failure (e.g. sold out) — no tx was ever attempted
+                  : "idle";
+
+  const bannerError =
+    bannerStatus === "wallet_error"
+      ? walletState.error
+      : bannerStatus === "reconcile_failed" || (bannerStatus === "failed" && chainStatus === "idle")
+        ? paymentError
+        : chainError;
+
+  const bannerRetry =
+    bannerStatus === "wallet_error"
+      ? handlePrimaryClick
+      : bannerStatus === "reconcile_failed"
+        ? () => void onStatusChange?.({ isConfirmed: true, isPaid })
+        : bannerStatus === "failed"
+          ? handleRetry
+          : undefined;
 
   return (
     <div className="p-8 border border-[#E9E9E9] rounded-xl space-y-6 dark:border-[#232323] w-full">
@@ -400,27 +395,20 @@ export const TicketInfo: FC<TicketInfoProps> = ({
             </div>
           </div>
 
-          {/* Tx banner */}
-          {txState.status !== "idle" && (
-            <TransactionStatusBanner
-              status={txState.status}
-              txHash={txState.txHash}
-              error={txState.error}
-              onRetry={txState.status === "failed" ? handleRetry : undefined}
-            />
-          )}
+          {/* Unified failure/status banner — covers wallet errors, chain
+              delays, stalled connections, on-chain failures, and partial
+              (on-chain-ok-but-not-reconciled) confirmations in one place. */}
+          <TransactionStatusBanner
+            status={bannerStatus}
+            txHash={chainTxHash}
+            error={bannerError}
+            retryLabel={bannerStatus === "reconcile_failed" ? "Retry Confirmation" : undefined}
+            onRetry={bannerRetry}
+            onCheckConnection={bannerStatus === "stalled" ? checkConnection : undefined}
+          />
 
           {/* Cooldown message */}
           <CooldownMessage remainingSeconds={remainingSeconds} />
-
-          {/* Payment error from parent (e.g. sold out, reconcile failure) */}
-          {hasPaymentFailed && txState.status === "idle" && (
-            <div className="bg-[#FFF2F2] border border-[#FBCACA] text-[#B42318] py-3 px-5 rounded-lg">
-              <p className="text-xs font-medium">
-                {paymentError ?? "Payment failed. Please retry."}
-              </p>
-            </div>
-          )}
 
           <div className="bg-[#F2FFF2] dark:bg-[#131313] dark:text-[#0BD330] text-[#0ABA2A] py-3 px-5 gap-4 flex">
             <DangerIcon />
@@ -452,9 +440,6 @@ export const TicketInfo: FC<TicketInfoProps> = ({
                 <>{buttonLabel()}</>
               )}
             </button>
-            {walletState.error && (
-              <p className="mt-2 text-sm text-red-500">{walletState.error}</p>
-            )}
           </div>
         </fieldset>
       </form>

--- a/app/components/explore/EventDetailClient.tsx
+++ b/app/components/explore/EventDetailClient.tsx
@@ -39,15 +39,17 @@ export default function EventDetailClient({ event }: EventDetailClientProps) {
   const [paymentError, setPaymentError] = useState<string | null>(null);
   const [attemptId, setAttemptId] = useState<string | null>(null);
 
-  const [isOptimistic, setIsOptimistic] = useState(false);
-
-  const isReallyPurchased = isConfirmed && isPaid;
-  const isPurchased = isOptimistic || isReallyPurchased;
+  // Only switch to the purchased view once the ticket is *actually*
+  // reconciled. Switching away from TicketInfo any earlier (e.g. as soon as
+  // the on-chain tx confirms) would unmount it mid-reconcile, wiping the
+  // chain status/txHash it needs to show a correct "reconcile failed —
+  // don't double-pay" message and to retry reconciliation without
+  // re-triggering a new wallet payment.
+  const isPurchased = isConfirmed && isPaid;
 
   const resetPaymentAttemptState = () => {
     setPaymentStatus("idle");
     setPaymentError(null);
-    setIsOptimistic(false);
     setAttemptId(null);
   };
 
@@ -114,13 +116,12 @@ export default function EventDetailClient({ event }: EventDetailClientProps) {
       return { ok: false, error: "Payment already in progress." };
     }
 
-    if (isReallyPurchased) {
+    if (isPurchased) {
       return { ok: false, error: "Payment already completed." };
     }
 
     if (event.slotsLeft < 1) {
       setAttemptId(null);
-      setIsOptimistic(false);
       setPaymentStatus("failed");
       setPaymentError("Tickets are sold out for this event.");
       return { ok: false, error: "Tickets are sold out for this event." };
@@ -128,7 +129,6 @@ export default function EventDetailClient({ event }: EventDetailClientProps) {
 
     const nextAttemptId = attemptId ?? createAttemptId();
     setAttemptId(nextAttemptId);
-    setIsOptimistic(true);
     setPaymentStatus("processing");
     setPaymentError(null);
 
@@ -144,12 +144,10 @@ export default function EventDetailClient({ event }: EventDetailClientProps) {
 
       setIsConfirmed(status.isConfirmed);
       setIsPaid(status.isPaid);
-      setIsOptimistic(false);
       setAttemptId(null);
       resetPaymentAttemptState();
       return { ok: true };
     } catch (error) {
-      setIsOptimistic(false);
       setIsConfirmed(false);
       setIsPaid(false);
       setPaymentStatus("failed");
@@ -198,7 +196,6 @@ export default function EventDetailClient({ event }: EventDetailClientProps) {
       ) : (
         <div className="max-w-[550px] mx-auto py-10">
           <PurchasedStage
-            isConfirming={isOptimistic && !isReallyPurchased}
             onCancelRegistration={() => setShowCancelModal(true)}
           />
         </div>
@@ -214,7 +211,6 @@ export default function EventDetailClient({ event }: EventDetailClientProps) {
         onConfirm={(_, __, updatedState) => {
           setIsConfirmed(updatedState.isConfirmed);
           setIsPaid(updatedState.isPaid);
-          setIsOptimistic(false);
           setAttemptId(null);
           resetPaymentAttemptState();
           setShowCancelModal(false);

--- a/app/components/explore/EventDetailClient.tsx
+++ b/app/components/explore/EventDetailClient.tsx
@@ -45,7 +45,12 @@ export default function EventDetailClient({ event }: EventDetailClientProps) {
   // chain status/txHash it needs to show a correct "reconcile failed —
   // don't double-pay" message and to retry reconciliation without
   // re-triggering a new wallet payment.
-  const isPurchased = isConfirmed && isPaid;
+  //
+  // Gate on the event's own paid-ness rather than the reconciled `isPaid`
+  // flag: free events reconcile with isPaid=false (see the anonymous path in
+  // TicketInfo), so requiring isPaid here would strand free-event purchases
+  // on the checkout view forever.
+  const isPurchased = isConfirmed && (event.isPaid ? isPaid : true);
 
   const resetPaymentAttemptState = () => {
     setPaymentStatus("idle");

--- a/app/components/explore/EventDetailClient.tsx
+++ b/app/components/explore/EventDetailClient.tsx
@@ -52,12 +52,19 @@ export default function EventDetailClient({ event }: EventDetailClientProps) {
   // on the checkout view forever.
   const isPurchased = isConfirmed && (event.isPaid ? isPaid : true);
 
+  /** Clears any in-progress/failed payment attempt back to a clean idle state. */
   const resetPaymentAttemptState = () => {
     setPaymentStatus("idle");
     setPaymentError(null);
     setAttemptId(null);
   };
 
+  /**
+   * Generates a stable idempotency key for a purchase attempt. The same key is
+   * reused across retries so the reconcile endpoint can dedupe them into one
+   * ticket. Falls back to a timestamp+random id where `crypto.randomUUID` is
+   * unavailable.
+   */
   const createAttemptId = () => {
     if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
       return crypto.randomUUID();
@@ -65,6 +72,12 @@ export default function EventDetailClient({ event }: EventDetailClientProps) {
     return `attempt_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`;
   };
 
+  /**
+   * Calls the reconcile endpoint to finalize a confirmed payment into a ticket.
+   * Normalizes HTTP errors, rejected payloads, and network failures into a
+   * single `{ ok, error }` result so callers don't have to branch on transport
+   * details.
+   */
   const reconcileWithBackend = async (
     nextAttemptId: string,
     status: { isConfirmed: boolean; isPaid: boolean },
@@ -113,6 +126,13 @@ export default function EventDetailClient({ event }: EventDetailClientProps) {
     }
   };
 
+  /**
+   * Entry point passed to {@link TicketInfo} as `onStatusChange`. Guards against
+   * concurrent/duplicate attempts and sold-out events, then drives the
+   * reconcile step, updating `paymentStatus`/`paymentError` so the checkout
+   * banner reflects the outcome. Safe to call again on retry — it reuses the
+   * existing `attemptId`.
+   */
   const handleStatusChange = async (status: {
     isConfirmed: boolean;
     isPaid: boolean;

--- a/app/components/organizer/ConnectWalletPrompt.tsx
+++ b/app/components/organizer/ConnectWalletPrompt.tsx
@@ -8,6 +8,11 @@ import { loadWalletSDK, preloadWalletSDK, WalletLoadState } from "@/lib/walletSd
 import { useUserSessionSync } from "@/lib/user-session-sync";
 import { TransactionStatusBanner } from "@/components/TransactionStatusBanner";
 
+/**
+ * Organizer-facing prompt to connect a wallet for receiving payments. Surfaces
+ * connect errors through the shared {@link TransactionStatusBanner} so wallet
+ * failures look consistent with the attendee checkout flow.
+ */
 export default function ConnectWalletPrompt() {
   const [walletState, setWalletState] = useState<WalletLoadState>({
     isLoading: false,
@@ -15,6 +20,7 @@ export default function ConnectWalletPrompt() {
   });
   const { walletConnected, setWalletConnected } = useUserSessionSync();
 
+  /** Loads the wallet SDK and reflects the outcome in local wallet state. */
   async function handleConnectWallet() {
     trackAnalyticsEvent("wallet_connect_cta_clicked", { source: "organizer_prompt" });
     setWalletState({ isLoading: true, error: null });

--- a/app/components/organizer/ConnectWalletPrompt.tsx
+++ b/app/components/organizer/ConnectWalletPrompt.tsx
@@ -6,6 +6,7 @@ import { useState } from "react";
 import { trackAnalyticsEvent } from "@/lib/privacyAnalytics";
 import { loadWalletSDK, preloadWalletSDK, WalletLoadState } from "@/lib/walletSdk";
 import { useUserSessionSync } from "@/lib/user-session-sync";
+import { TransactionStatusBanner } from "@/components/TransactionStatusBanner";
 
 export default function ConnectWalletPrompt() {
   const [walletState, setWalletState] = useState<WalletLoadState>({
@@ -70,7 +71,12 @@ export default function ConnectWalletPrompt() {
             )}
           </button>
           {walletState.error && (
-            <p className="mt-2 text-sm text-red-500">{walletState.error}</p>
+            <TransactionStatusBanner
+              status="wallet_error"
+              error={walletState.error}
+              onRetry={handleConnectWallet}
+              className="mt-3 text-left"
+            />
           )}
         </div>
       </div>

--- a/app/components/organizer/ConnectWalletPrompt.tsx
+++ b/app/components/organizer/ConnectWalletPrompt.tsx
@@ -74,6 +74,7 @@ export default function ConnectWalletPrompt() {
             <TransactionStatusBanner
               status="wallet_error"
               error={walletState.error}
+              hint="Make sure your wallet extension is unlocked, then try again."
               onRetry={handleConnectWallet}
               className="mt-3 text-left"
             />

--- a/components/TransactionStatusBanner.tsx
+++ b/components/TransactionStatusBanner.tsx
@@ -123,7 +123,10 @@ const DEFAULT_MESSAGES: Partial<Record<BannerStatus, string>> = {
   wallet_error: "Failed to load wallet. Please try again.",
 }
 
-const DEFAULT_EXPLORER_BASE_URL = "https://stellar.expert/explorer/public/tx"
+// Allows non-production environments (e.g. testnet) to point at the right
+// explorer without every call site having to pass explorerBaseUrl.
+const DEFAULT_EXPLORER_BASE_URL =
+  process.env.NEXT_PUBLIC_EXPLORER_BASE_URL ?? "https://stellar.expert/explorer/public/tx"
 const DEFAULT_EXPLORER_LABEL = "View on Stellar Expert"
 
 export function TransactionStatusBanner({
@@ -142,9 +145,8 @@ export function TransactionStatusBanner({
   className,
 }: TransactionStatusBannerProps) {
   const config = CONFIG[status]
-  if (!config) return null
-
-  const Icon = config.icon
+  const Icon = config?.icon
+  const role = config?.role ?? "status"
 
   const message =
     status === "pending"
@@ -153,7 +155,7 @@ export function TransactionStatusBanner({
       ? confirmedMessage
       : (failedMessage ?? error ?? DEFAULT_MESSAGES[status] ?? "Something went wrong. Please try again.")
 
-  const hintText = hint ?? config.hint
+  const hintText = hint ?? config?.hint
 
   const showExplorerLink = txHash && status !== "pending" && status !== "wallet_error"
   const showHashPreview = txHash && status === "pending"
@@ -162,97 +164,106 @@ export function TransactionStatusBanner({
   const showStalledRetryFallback = status === "stalled" && !onCheckConnection && onRetry
 
   return (
+    // The live-region wrapper is always mounted (even for "idle", when it's
+    // empty and visually collapses to nothing) so screen readers are already
+    // observing it before the first status text appears — a freshly-inserted
+    // role="status"/"alert" element can have its initial announcement missed.
     <div
-      role={config.role}
-      aria-live={config.role === "status" ? "polite" : undefined}
+      role={role}
+      aria-live={role === "status" ? "polite" : undefined}
       className={cn(
-        "flex items-start gap-3 rounded-xl border px-4 py-3 transition-all duration-300",
-        config.wrapperClass,
+        "flex items-start gap-3 transition-all duration-300",
+        config && "rounded-xl border px-4 py-3",
+        config?.wrapperClass,
         className
       )}
     >
-      {/* Icon */}
-      <Icon aria-hidden="true" className={cn("mt-0.5 size-5 shrink-0", config.iconClass)} />
+      {config && Icon && (
+        <>
+          {/* Icon */}
+          <Icon aria-hidden="true" className={cn("mt-0.5 size-5 shrink-0", config.iconClass)} />
 
-      {/* Body */}
-      <div className="flex-1 min-w-0 space-y-0.5">
-        <div className="flex items-center justify-between gap-2">
-          <p className={cn("text-sm font-semibold", config.textClass)}>
-            {config.heading}
-          </p>
-        </div>
+          {/* Body */}
+          <div className="flex-1 min-w-0 space-y-0.5">
+            <div className="flex items-center justify-between gap-2">
+              <p className={cn("text-sm font-semibold", config.textClass)}>
+                {config.heading}
+              </p>
+            </div>
 
-        <p className={cn("text-xs leading-relaxed", config.textClass, "opacity-90")}>
-          {message}
-        </p>
+            <p className={cn("text-xs leading-relaxed", config.textClass, "opacity-90")}>
+              {message}
+            </p>
 
-        {/* Explorer link — shown when we have a hash */}
-        {showExplorerLink && txHash && (
-          <Link
-            href={`${explorerBaseUrl}/${txHash}`}
-            target="_blank"
-            rel="noopener noreferrer"
-            className={cn(
-              "inline-flex items-center gap-1 text-xs underline underline-offset-2 mt-1",
-              config.textClass
+            {/* Explorer link — shown when we have a hash */}
+            {showExplorerLink && txHash && (
+              <Link
+                href={`${explorerBaseUrl}/${txHash}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className={cn(
+                  "inline-flex items-center gap-1 text-xs underline underline-offset-2 mt-1",
+                  config.textClass
+                )}
+              >
+                {explorerLabel} ↗
+              </Link>
             )}
-          >
-            {explorerLabel} ↗
-          </Link>
-        )}
 
-        {/* Shortened hash shown while pending */}
-        {showHashPreview && txHash && (
-          <p className={cn("text-xs font-mono opacity-60 truncate", config.textClass)}>
-            {txHash.slice(0, 12)}…{txHash.slice(-8)}
-          </p>
-        )}
-
-        {/* Reassurance / caution hint, mirroring the design's "Safe to retry" note */}
-        {hintText && (
-          <div
-            className={cn(
-              "mt-2 flex items-start gap-1.5 rounded-lg bg-black/[0.03] dark:bg-white/[0.04] px-2.5 py-1.5 text-[11px] leading-relaxed",
-              config.textClass,
-              "opacity-90"
+            {/* Shortened hash shown while pending */}
+            {showHashPreview && txHash && (
+              <p className={cn("text-xs font-mono opacity-60 truncate", config.textClass)}>
+                {txHash.slice(0, 12)}…{txHash.slice(-8)}
+              </p>
             )}
-          >
-            <ShieldCheck aria-hidden="true" className="size-3.5 shrink-0 mt-0.5" />
-            <span>{hintText}</span>
+
+            {/* Reassurance / caution hint, mirroring the design's "Safe to retry" note */}
+            {hintText && (
+              <div
+                className={cn(
+                  "mt-2 flex items-start gap-1.5 rounded-lg bg-black/[0.03] dark:bg-white/[0.04] px-2.5 py-1.5 text-[11px] leading-relaxed",
+                  config.textClass,
+                  "opacity-90"
+                )}
+              >
+                <ShieldCheck aria-hidden="true" className="size-3.5 shrink-0 mt-0.5" />
+                <span>{hintText}</span>
+              </div>
+            )}
+
+            {/* Actions */}
+            <div className="flex items-center gap-4 mt-2">
+              {showCheckConnection && (
+                <button
+                  type="button"
+                  onClick={onCheckConnection}
+                  className={cn(
+                    "inline-flex items-center gap-1.5 text-xs font-semibold underline underline-offset-2",
+                    config.textClass
+                  )}
+                >
+                  <RotateCcw size={12} aria-hidden="true" />
+                  Check Connection
+                </button>
+              )}
+
+              {(showRetry || showStalledRetryFallback) && (
+                <button
+                  type="button"
+                  onClick={onRetry}
+                  className={cn(
+                    "inline-flex items-center gap-1.5 text-xs font-semibold underline underline-offset-2",
+                    config.textClass
+                  )}
+                >
+                  <RotateCcw size={12} aria-hidden="true" />
+                  {retryLabel ?? "Try again"}
+                </button>
+              )}
+            </div>
           </div>
-        )}
-
-        {/* Actions */}
-        <div className="flex items-center gap-4 mt-2">
-          {showCheckConnection && (
-            <button
-              type="button"
-              onClick={onCheckConnection}
-              className={cn(
-                "inline-flex items-center gap-1.5 text-xs font-semibold underline underline-offset-2",
-                config.textClass
-              )}
-            >
-              <RotateCcw size={12} aria-hidden="true" />
-              Check Connection
-            </button>
-          )}
-
-          {(showRetry || showStalledRetryFallback) && (
-            <button
-              type="button"
-              onClick={onRetry}
-              className={cn(
-                "inline-flex items-center gap-1.5 text-xs font-semibold underline underline-offset-2",
-                config.textClass
-              )}
-            >
-              <RotateCcw size={12} aria-hidden="true" />
-              {retryLabel ?? "Try again"}
-            </button>
-          )}
-        </div>
-      </div>
+        </>
+      )}
     </div>
   )
 }

--- a/components/TransactionStatusBanner.tsx
+++ b/components/TransactionStatusBanner.tsx
@@ -130,6 +130,14 @@ const DEFAULT_EXPLORER_BASE_URL =
   process.env.NEXT_PUBLIC_EXPLORER_BASE_URL ?? "https://stellar.expert/explorer/public/tx"
 const DEFAULT_EXPLORER_LABEL = "View on Stellar Expert"
 
+/**
+ * Unified status/failure banner for the checkout and wallet flows. Renders one
+ * message per {@link BannerStatus} (pending, stalled, confirmed, reconciling,
+ * failed, reconcile_failed, wallet_error) with status-appropriate copy, an
+ * optional explorer link, a reassurance/caution hint, and retry /
+ * check-connection actions. The live-region wrapper stays mounted even when
+ * idle so screen readers don't miss the first announcement.
+ */
 export function TransactionStatusBanner({
   status,
   txHash,
@@ -274,6 +282,11 @@ export interface TxStatusDotProps {
   className?: string
 }
 
+/**
+ * Compact colored-dot + label indicator for a transaction status, for use in
+ * tight spaces (lists, headers) where the full {@link TransactionStatusBanner}
+ * would be too heavy. Renders nothing while idle.
+ */
 export function TxStatusDot({ status, className }: TxStatusDotProps) {
   if (status === "idle") return null
 

--- a/components/TransactionStatusBanner.tsx
+++ b/components/TransactionStatusBanner.tsx
@@ -1,22 +1,46 @@
 "use client"
 
 import React from "react"
-import { CheckCircle2, XCircle, Loader2, RotateCcw } from "lucide-react"
+import {
+  CheckCircle2,
+  XCircle,
+  Loader2,
+  RotateCcw,
+  WifiOff,
+  Wallet,
+  ShieldCheck,
+} from "lucide-react"
 import { cn } from "@/lib/utils"
 import type { TransactionStatus } from "@/hooks/useTransactionStatus"
 import Link from "next/link";
 
+/**
+ * Extends the on-chain polling states from useTransactionStatus with two
+ * states that live above it: "reconciling" (on-chain confirmed, backend
+ * finalization still in flight) and "reconcile_failed" (on-chain confirmed,
+ * backend rejected/errored — funds already moved, don't double-pay) and
+ * "wallet_error" (wallet connect/signing failed before any tx exists).
+ */
+export type BannerStatus = TransactionStatus | "reconciling" | "reconcile_failed" | "wallet_error"
+
 export interface TransactionStatusBannerProps {
-  status: TransactionStatus
+  status: BannerStatus
   txHash?: string | null
   error?: string | null
   pendingMessage?: string
   confirmedMessage?: string
   failedMessage?: string
+  /** Overrides the default reassurance/caution line shown under the message. */
+  hint?: string
+  /** Label for the primary retry action. Defaults to a status-appropriate label. */
+  retryLabel?: string
   onRetry?: () => void
+  /** Shown alongside onRetry for "stalled" — a lighter-weight re-check action. */
+  onCheckConnection?: () => void
+  explorerBaseUrl?: string
+  explorerLabel?: string
   className?: string
 }
-
 
 const CONFIG = {
   idle: null,
@@ -26,7 +50,19 @@ const CONFIG = {
     wrapperClass:
       "bg-[#F5EEFF] dark:bg-[#1C0F2E] border-[#D4ADFC] dark:border-[#4A1F7A]",
     textClass: "text-[#6917AF] dark:text-[#D7B5F5]",
-    label: "Pending",
+    heading: "Transaction Pending",
+    role: "status" as const,
+    hint: "Safe to retry — no funds have moved yet.",
+  },
+  stalled: {
+    icon: WifiOff,
+    iconClass: "text-amber-600 dark:text-amber-400",
+    wrapperClass:
+      "bg-amber-50 dark:bg-amber-950/30 border-amber-200 dark:border-amber-800/40",
+    textClass: "text-amber-800 dark:text-amber-300",
+    heading: "Network Issue Detected",
+    role: "alert" as const,
+    hint: "Safe to retry — no assets have been deducted. You can keep waiting or check your connection.",
   },
   confirmed: {
     icon: CheckCircle2,
@@ -34,7 +70,19 @@ const CONFIG = {
     wrapperClass:
       "bg-[#ECFDF3] dark:bg-[#052E16] border-[#6CE9A6] dark:border-[#166534]",
     textClass: "text-[#027A48] dark:text-[#4ADE80]",
-    label: "Confirmed",
+    heading: "Transaction Confirmed",
+    role: "status" as const,
+    hint: undefined,
+  },
+  reconciling: {
+    icon: Loader2,
+    iconClass: "animate-spin text-blue-600 dark:text-blue-400",
+    wrapperClass:
+      "bg-blue-50 dark:bg-blue-950/30 border-blue-200 dark:border-blue-800/40",
+    textClass: "text-blue-700 dark:text-blue-300",
+    heading: "Finalizing Your Ticket",
+    role: "status" as const,
+    hint: "Your payment is confirmed on-chain. Please don't submit another payment while we finalize your ticket.",
   },
   failed: {
     icon: XCircle,
@@ -42,13 +90,41 @@ const CONFIG = {
     wrapperClass:
       "bg-[#FEF3F2] dark:bg-[#2D0B09] border-[#FDA29B] dark:border-[#7F1D1D]",
     textClass: "text-[#B42318] dark:text-[#F87171]",
-    label: "Failed",
+    heading: "Transaction Failed",
+    role: "alert" as const,
+    hint: "Safe to retry — no funds were deducted from this attempt.",
+  },
+  reconcile_failed: {
+    icon: XCircle,
+    iconClass: "text-[#D92D20]",
+    wrapperClass:
+      "bg-[#FEF3F2] dark:bg-[#2D0B09] border-[#FDA29B] dark:border-[#7F1D1D]",
+    textClass: "text-[#B42318] dark:text-[#F87171]",
+    heading: "Confirmation Failed",
+    role: "alert" as const,
+    hint: "Don't submit another payment — retrying just re-checks your existing one.",
+  },
+  wallet_error: {
+    icon: Wallet,
+    iconClass: "text-[#D92D20]",
+    wrapperClass:
+      "bg-[#FEF3F2] dark:bg-[#2D0B09] border-[#FDA29B] dark:border-[#7F1D1D]",
+    textClass: "text-[#B42318] dark:text-[#F87171]",
+    heading: "Wallet Error",
+    role: "alert" as const,
+    hint: "Check your wallet before retrying — avoid approving another payment if one is already pending there.",
   },
 } as const
 
-function explorerUrl(txHash: string) {
-  return `https://solscan.io/tx/${txHash}`
+const DEFAULT_MESSAGES: Partial<Record<BannerStatus, string>> = {
+  stalled: "The transaction status is currently unknown due to a connection problem. It usually resolves on its own.",
+  reconciling: "Payment confirmed on-chain. Finalizing your ticket…",
+  reconcile_failed: "Your payment was confirmed on-chain, but we couldn't finalize your ticket.",
+  wallet_error: "Failed to load wallet. Please try again.",
 }
+
+const DEFAULT_EXPLORER_BASE_URL = "https://stellar.expert/explorer/public/tx"
+const DEFAULT_EXPLORER_LABEL = "View on Stellar Expert"
 
 export function TransactionStatusBanner({
   status,
@@ -57,7 +133,12 @@ export function TransactionStatusBanner({
   pendingMessage = "Confirming your ticket purchase…",
   confirmedMessage = "Ticket confirmed! You're all set.",
   failedMessage,
+  hint,
+  retryLabel,
   onRetry,
+  onCheckConnection,
+  explorerBaseUrl = DEFAULT_EXPLORER_BASE_URL,
+  explorerLabel = DEFAULT_EXPLORER_LABEL,
   className,
 }: TransactionStatusBannerProps) {
   const config = CONFIG[status]
@@ -70,12 +151,20 @@ export function TransactionStatusBanner({
       ? pendingMessage
       : status === "confirmed"
       ? confirmedMessage
-      : (failedMessage ?? error ?? "Something went wrong. Please try again.")
+      : (failedMessage ?? error ?? DEFAULT_MESSAGES[status] ?? "Something went wrong. Please try again.")
+
+  const hintText = hint ?? config.hint
+
+  const showExplorerLink = txHash && status !== "pending" && status !== "wallet_error"
+  const showHashPreview = txHash && status === "pending"
+  const showCheckConnection = status === "stalled" && onCheckConnection
+  const showRetry = (status === "failed" || status === "reconcile_failed" || status === "wallet_error") && onRetry
+  const showStalledRetryFallback = status === "stalled" && !onCheckConnection && onRetry
 
   return (
     <div
-      role="status"
-      aria-live="polite"
+      role={config.role}
+      aria-live={config.role === "status" ? "polite" : undefined}
       className={cn(
         "flex items-start gap-3 rounded-xl border px-4 py-3 transition-all duration-300",
         config.wrapperClass,
@@ -83,13 +172,13 @@ export function TransactionStatusBanner({
       )}
     >
       {/* Icon */}
-      <Icon className={cn("mt-0.5 size-5 shrink-0", config.iconClass)} />
+      <Icon aria-hidden="true" className={cn("mt-0.5 size-5 shrink-0", config.iconClass)} />
 
       {/* Body */}
       <div className="flex-1 min-w-0 space-y-0.5">
         <div className="flex items-center justify-between gap-2">
           <p className={cn("text-sm font-semibold", config.textClass)}>
-            Transaction {config.label}
+            {config.heading}
           </p>
         </div>
 
@@ -98,9 +187,9 @@ export function TransactionStatusBanner({
         </p>
 
         {/* Explorer link — shown when we have a hash */}
-        {txHash && status !== "pending" && (
+        {showExplorerLink && txHash && (
           <Link
-            href={explorerUrl(txHash)}
+            href={`${explorerBaseUrl}/${txHash}`}
             target="_blank"
             rel="noopener noreferrer"
             className={cn(
@@ -108,31 +197,61 @@ export function TransactionStatusBanner({
               config.textClass
             )}
           >
-            View on Solscan ↗
+            {explorerLabel} ↗
           </Link>
         )}
 
         {/* Shortened hash shown while pending */}
-        {txHash && status === "pending" && (
+        {showHashPreview && txHash && (
           <p className={cn("text-xs font-mono opacity-60 truncate", config.textClass)}>
             {txHash.slice(0, 12)}…{txHash.slice(-8)}
           </p>
         )}
 
-        {/* Retry button on failure */}
-        {status === "failed" && onRetry && (
-          <button
-            type="button"
-            onClick={onRetry}
+        {/* Reassurance / caution hint, mirroring the design's "Safe to retry" note */}
+        {hintText && (
+          <div
             className={cn(
-              "mt-2 inline-flex items-center gap-1.5 text-xs font-semibold underline underline-offset-2",
-              config.textClass
+              "mt-2 flex items-start gap-1.5 rounded-lg bg-black/[0.03] dark:bg-white/[0.04] px-2.5 py-1.5 text-[11px] leading-relaxed",
+              config.textClass,
+              "opacity-90"
             )}
           >
-            <RotateCcw size={12} />
-            Try again
-          </button>
+            <ShieldCheck aria-hidden="true" className="size-3.5 shrink-0 mt-0.5" />
+            <span>{hintText}</span>
+          </div>
         )}
+
+        {/* Actions */}
+        <div className="flex items-center gap-4 mt-2">
+          {showCheckConnection && (
+            <button
+              type="button"
+              onClick={onCheckConnection}
+              className={cn(
+                "inline-flex items-center gap-1.5 text-xs font-semibold underline underline-offset-2",
+                config.textClass
+              )}
+            >
+              <RotateCcw size={12} aria-hidden="true" />
+              Check Connection
+            </button>
+          )}
+
+          {(showRetry || showStalledRetryFallback) && (
+            <button
+              type="button"
+              onClick={onRetry}
+              className={cn(
+                "inline-flex items-center gap-1.5 text-xs font-semibold underline underline-offset-2",
+                config.textClass
+              )}
+            >
+              <RotateCcw size={12} aria-hidden="true" />
+              {retryLabel ?? "Try again"}
+            </button>
+          )}
+        </div>
       </div>
     </div>
   )
@@ -148,12 +267,14 @@ export function TxStatusDot({ status, className }: TxStatusDotProps) {
 
   const dotClass = {
     pending: "bg-[#6917AF] animate-pulse",
+    stalled: "bg-amber-500 animate-pulse",
     confirmed: "bg-[#039855]",
     failed: "bg-[#D92D20]",
   }[status]
 
   const label = {
     pending: "Pending",
+    stalled: "Connection issue",
     confirmed: "Confirmed",
     failed: "Failed",
   }[status]

--- a/components/TransactionStatusBanner.tsx
+++ b/components/TransactionStatusBanner.tsx
@@ -52,7 +52,8 @@ const CONFIG = {
     textClass: "text-[#6917AF] dark:text-[#D7B5F5]",
     heading: "Transaction Pending",
     role: "status" as const,
-    hint: "Safe to retry — no funds have moved yet.",
+    // Tx already submitted — do not encourage another payment while we wait.
+    hint: "Please wait — don't submit another payment while this confirms.",
   },
   stalled: {
     icon: WifiOff,

--- a/hooks/useTransactionStatus.ts
+++ b/hooks/useTransactionStatus.ts
@@ -2,7 +2,10 @@
 
 import { useState, useEffect, useCallback, useRef } from "react"
 
-export type TransactionStatus = "idle" | "pending" | "confirmed" | "failed"
+export type TransactionStatus = "idle" | "pending" | "stalled" | "confirmed" | "failed"
+
+/** Consecutive network failures before we surface a "stalled" state to the user. */
+const STALL_THRESHOLD = 2
 
 export interface TransactionState {
     status: TransactionStatus
@@ -47,6 +50,7 @@ export function useTransactionStatus(options: UseTransactionStatusOptions = {}) 
     const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
     const stateRef = useRef(state)
     stateRef.current = state
+    const consecutiveFailuresRef = useRef(0)
 
     // Stable callbacks so the interval closure doesn't go stale
     const onConfirmedRef = useRef(onConfirmed)
@@ -71,8 +75,11 @@ export function useTransactionStatus(options: UseTransactionStatusOptions = {}) 
             current.attempts >= maxAttempts
         ) {
             stopPolling()
-            // Mark as failed if we ran out of attempts
-            if (current.attempts >= maxAttempts && current.status === "pending") {
+            // Mark as failed if we ran out of attempts while still waiting
+            if (
+                current.attempts >= maxAttempts &&
+                (current.status === "pending" || current.status === "stalled")
+            ) {
                 setState((s) => ({
                     ...s,
                     status: "failed",
@@ -86,6 +93,7 @@ export function useTransactionStatus(options: UseTransactionStatusOptions = {}) 
 
         try {
             const result = await fetchTransactionStatus(txHash)
+            consecutiveFailuresRef.current = 0
 
             setState((s) => ({
                 ...s,
@@ -103,10 +111,30 @@ export function useTransactionStatus(options: UseTransactionStatusOptions = {}) 
                 onFailedRef.current?.(result.error ?? "Transaction failed")
             }
         } catch (err) {
-            // Network error — increment attempts but keep polling
-            setState((s) => ({ ...s, attempts: s.attempts + 1 }))
+            // Network error — keep polling in the background, but surface a
+            // "stalled" state after a couple of consecutive failures so the
+            // user isn't left staring at a silent spinner.
+            consecutiveFailuresRef.current += 1
+            setState((s) => ({
+                ...s,
+                status:
+                    s.status === "pending" && consecutiveFailuresRef.current >= STALL_THRESHOLD
+                        ? "stalled"
+                        : s.status,
+                attempts: s.attempts + 1,
+            }))
         }
     }, [maxAttempts, stopPolling])
+
+    /**
+     * Fires one immediate poll without resetting the interval/attempt count.
+     * Intended for a manual "Check Connection" / "Retry Status Check" action
+     * while stalled.
+     */
+    const checkConnection = useCallback(() => {
+        const { txHash } = stateRef.current
+        if (txHash) poll(txHash)
+    }, [poll])
 
     /**
      * Call this as soon as you have a transaction hash from the wallet.
@@ -115,6 +143,7 @@ export function useTransactionStatus(options: UseTransactionStatusOptions = {}) 
     const startTracking = useCallback(
         (txHash: string) => {
             stopPolling()
+            consecutiveFailuresRef.current = 0
 
             setState({
                 status: "pending",
@@ -134,11 +163,12 @@ export function useTransactionStatus(options: UseTransactionStatusOptions = {}) 
     /** Reset everything back to idle */
     const reset = useCallback(() => {
         stopPolling()
+        consecutiveFailuresRef.current = 0
         setState(INITIAL_STATE)
     }, [stopPolling])
 
     // Cleanup on unmount
     useEffect(() => () => stopPolling(), [stopPolling])
 
-    return { ...state, startTracking, reset }
+    return { ...state, startTracking, reset, checkConnection }
 }

--- a/hooks/useTransactionStatus.ts
+++ b/hooks/useTransactionStatus.ts
@@ -22,6 +22,7 @@ export interface UseTransactionStatusOptions {
     onFailed?: (error: string) => void
 }
 
+/** Fetches the current on-chain status for a tx hash from the status API. */
 async function fetchTransactionStatus(
     txHash: string
 ): Promise<{ status: "pending" | "confirmed" | "failed"; error?: string }> {
@@ -38,6 +39,15 @@ const INITIAL_STATE: TransactionState = {
     attempts: 0,
 }
 
+/**
+ * Polls the transaction status API for a tx hash and exposes its lifecycle
+ * (idle → pending → stalled/confirmed/failed) plus imperative controls. Handles
+ * timeout, transient-network "stalled" detection, and overlapping-request
+ * guarding so callers get a single reliable status stream.
+ *
+ * @returns the current state spread with `startTracking`, `reset`, and
+ * `checkConnection`.
+ */
 export function useTransactionStatus(options: UseTransactionStatusOptions = {}) {
     const {
         pollIntervalMs = 3_000,
@@ -70,6 +80,11 @@ export function useTransactionStatus(options: UseTransactionStatusOptions = {}) 
         }
     }, [])
 
+    /**
+     * Runs one status check: skips if a request is already in flight or the tx
+     * is terminal, times out after `maxAttempts`, and flips to "stalled" after
+     * repeated network failures. Fires onConfirmed/onFailed on terminal states.
+     */
     const poll = useCallback(async (txHash: string) => {
         if (inFlightRef.current) return
         const current = stateRef.current

--- a/hooks/useTransactionStatus.ts
+++ b/hooks/useTransactionStatus.ts
@@ -51,6 +51,11 @@ export function useTransactionStatus(options: UseTransactionStatusOptions = {}) 
     const stateRef = useRef(state)
     stateRef.current = state
     const consecutiveFailuresRef = useRef(0)
+    // Guards against the interval poll and a manual checkConnection() call
+    // overlapping — without it, concurrent requests double-increment
+    // `attempts`/`consecutiveFailuresRef` and can burn the attempt budget
+    // early from repeated manual clicks.
+    const inFlightRef = useRef(false)
 
     // Stable callbacks so the interval closure doesn't go stale
     const onConfirmedRef = useRef(onConfirmed)
@@ -66,6 +71,7 @@ export function useTransactionStatus(options: UseTransactionStatusOptions = {}) 
     }, [])
 
     const poll = useCallback(async (txHash: string) => {
+        if (inFlightRef.current) return
         const current = stateRef.current
 
         // Guard: stop if already terminal or exceeded attempts
@@ -91,6 +97,7 @@ export function useTransactionStatus(options: UseTransactionStatusOptions = {}) 
             return
         }
 
+        inFlightRef.current = true
         try {
             const result = await fetchTransactionStatus(txHash)
             consecutiveFailuresRef.current = 0
@@ -123,6 +130,8 @@ export function useTransactionStatus(options: UseTransactionStatusOptions = {}) 
                         : s.status,
                 attempts: s.attempts + 1,
             }))
+        } finally {
+            inFlightRef.current = false
         }
     }, [maxAttempts, stopPolling])
 

--- a/lib/walletSdk.ts
+++ b/lib/walletSdk.ts
@@ -60,9 +60,20 @@ export async function loadWalletSDK(): Promise<string> {
     // Clear after settle so a later purchase/retry gets a fresh tx hash.
     // Without this, every "Retry Payment" reuses the first mock hash and the
     // status API keeps returning the previous terminal result forever.
-    loadPromise.finally(() => {
-      loadPromise = null;
-    });
+    //
+    // Use then(onFulfilled, onRejected) rather than finally(): finally() returns
+    // a derived promise that rejects when loading fails, and nothing consumes
+    // it, so it would surface as an unhandled rejection. Both handlers clear the
+    // singleton; the original loadPromise is still returned so callers keep
+    // seeing the real error.
+    void loadPromise.then(
+      () => {
+        loadPromise = null;
+      },
+      () => {
+        loadPromise = null;
+      },
+    );
   }
   return loadPromise;
 }

--- a/lib/walletSdk.ts
+++ b/lib/walletSdk.ts
@@ -57,8 +57,10 @@ export async function loadWalletSDK(): Promise<string> {
     );
     // ── END MOCK ──────────────────────────────────────────────────────────────
 
-    // Reset on failure so callers can retry
-    loadPromise.catch(() => {
+    // Clear after settle so a later purchase/retry gets a fresh tx hash.
+    // Without this, every "Retry Payment" reuses the first mock hash and the
+    // status API keeps returning the previous terminal result forever.
+    loadPromise.finally(() => {
       loadPromise = null;
     });
   }


### PR DESCRIPTION
## Description

Closed #164 for GrantFox

Building on the failure-state design from #91, this implements a unified UX for wallet errors, blockchain delays, and partial (on-chain-confirmed-but-not-reconciled) confirmations. While wiring the design up to the real checkout flow, I found and fixed a bug where a failed backend reconcile after a successful on-chain payment could prompt the user to sign a second, duplicate payment.

### Changes

1. **Extended `TransactionStatusBanner`** — now covers `pending`, `stalled`, `confirmed`, `reconciling`, `failed`, `reconcile_failed`, and `wallet_error` states, each with status-appropriate copy and a "safe to retry" vs. "don't submit another payment" hint.
2. **Extended `useTransactionStatus`** — surfaces a `stalled` state after repeated network failures instead of silently retrying until a hard timeout, plus a `checkConnection` action.
3. **Fixed the transaction explorer link** — it pointed at Solscan (Solana) even though the design and app assets are Stellar-branded.
4. **Migrated `TicketInfo` onto the shared hook** — removed a duplicated inline polling loop and replaced two separate, sometimes-simultaneous ad-hoc error boxes with one derived banner status.
5. **Fixed a double-payment risk** — a failed backend reconcile after a successful on-chain payment could re-trigger a brand-new wallet signature on retry; retry now re-checks the existing payment instead.
6. **Fixed a related bug in `EventDetailClient`** — the checkout view switched to the "purchased" screen optimistically, before the backend had actually confirmed the ticket; if reconcile then failed, the checkout form remounted from scratch and lost the state needed to avoid a duplicate payment.
7. **Reused the same banner for wallet connect errors** in the organizer flow (`ConnectWalletPrompt`).
8. **Added accessibility roles** — `role="alert"`/`role="status"` and `aria-hidden` on icons per state.

### Verification

- ✅ `npm run build` passes
- ✅ `npx tsc --noEmit` passes with no new errors
- ✅ Manually exercised in the browser (light + dark theme, desktop viewport): full happy path, forced on-chain failure, forced reconcile failure (confirmed retry calls only the reconcile endpoint, no new wallet transaction), and forced wallet connect error on the organizer page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced payment banners with expanded states, including stalled transactions and clearer reconciliation/wallet error messaging.
  * Added retry and “check connection” actions, plus more customizable banner hints/labels and configurable explorer links.
* **Bug Fixes**
  * Improved behavior after on-chain confirmation to prevent duplicate payment flows and incorrect reconfirmation.
  * Reworked purchased/payment UI to remove optimistic “confirming” messaging and rely on confirmed reconciliation gating.
  * Updated reconciliation handling so free/anonymous events aren’t blocked by “not paid” values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->