### PR TITLE
feat: implement unified failure-state UX system for wallet/chain errors

### DIFF
--- a/app/api/payments/reconcile/route.ts
+++ b/app/api/payments/reconcile/route.ts
@@ -83,6 +83,15 @@ export async function POST(request: Request) {
 
   const existing = processedAttempts.get(attemptId);
   if (existing) {
+    // `attemptId` is client-supplied, so bind the dedup lookup to its original
+    // event. Otherwise replaying an attemptId with a different eventId would
+    // bypass the eligibility checks above and leak another attempt's ticketId.
+    if (existing.eventId !== eventId) {
+      return NextResponse.json(
+        { ok: false, error: "attemptId does not match this event." },
+        { status: 409 },
+      );
+    }
     return NextResponse.json({
       ok: true,
       ticketId: existing.ticketId,

--- a/app/api/payments/reconcile/route.ts
+++ b/app/api/payments/reconcile/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { dummyEvents } from "@/lib/dummyEvents/events";
 
 type ReconcileRequest = {
   attemptId?: string;
@@ -15,6 +16,19 @@ type TicketRecord = {
 
 const processedAttempts = new Map<string, TicketRecord>();
 
+/**
+ * Finalizes a ticket purchase after an on-chain payment (or free registration)
+ * has been confirmed. Idempotent by `attemptId`: replaying the same attempt
+ * returns the previously issued ticket instead of creating a duplicate, so a
+ * failed-then-retried reconcile can never issue two tickets or double-charge.
+ *
+ * Free-vs-paid eligibility is derived from server-side event data rather than
+ * the client's `isPaid` flag, so a paid event can't be reconciled for free.
+ *
+ * Responds 400 for malformed/missing fields, 404 for an unknown event, 409
+ * when the attempt isn't confirmed, 402 when a paid event lacks payment, and
+ * 200 with `{ ticketId, deduplicated }` on success.
+ */
 export async function POST(request: Request) {
   let body: ReconcileRequest;
 
@@ -37,10 +51,33 @@ export async function POST(request: Request) {
     );
   }
 
-  if (!body.isConfirmed || !body.isPaid) {
+  if (!body.isConfirmed) {
     return NextResponse.json(
       { ok: false, error: "Payment is not yet fully confirmed." },
       { status: 409 },
+    );
+  }
+
+  // Derive free/paid eligibility from server-side event data, not from the
+  // client-supplied `isPaid` flag. This stops a caller from reconciling a paid
+  // event for free by simply sending `isPaid: false`.
+  //
+  // NOTE: `dummyEvents` stands in for a real event store here. For a paid event
+  // this still trusts that the client-side wallet flow ran; production must
+  // replace this with verification of a settled on-chain payment tied to
+  // `attemptId` before issuing the ticket.
+  const event = dummyEvents.find((e) => e.id === eventId);
+  if (!event) {
+    return NextResponse.json(
+      { ok: false, error: "Unknown event." },
+      { status: 404 },
+    );
+  }
+
+  if (event.isPaid && !body.isPaid) {
+    return NextResponse.json(
+      { ok: false, error: "This event requires a completed payment." },
+      { status: 402 },
     );
   }
 

--- a/app/components/explore/EventCheckout/PurchasedStage.tsx
+++ b/app/components/explore/EventCheckout/PurchasedStage.tsx
@@ -2,30 +2,23 @@
 
 import { FC } from "react";
 import Image from "next/image";
-import { Loader2 } from "lucide-react";
 
 interface PurchasedStageProps {
-  isConfirming?: boolean;
   onViewAccessCode?: () => void;
   onCancelRegistration?: () => void;
 }
 
+/**
+ * Success screen shown once a ticket purchase is fully reconciled — the real
+ * "you're in" confirmation, as opposed to the in-flight status shown by the
+ * checkout banner. Offers access-code and cancel-registration actions.
+ */
 export const PurchasedStage: FC<PurchasedStageProps> = ({
-  isConfirming = false,
   onViewAccessCode,
   onCancelRegistration,
 }) => {
   return (
     <div className="p-8 border border-[#E9E9E9] rounded-2xl dark:border-[#232323] w-full bg-white dark:bg-[#0A0A0A] shadow-[0_4px_20px_rgba(0,0,0,0.03)] font-work-sans">
-      {isConfirming && (
-        <div className="flex items-center gap-2 mb-5 bg-[#F5EEFF] dark:bg-[#1C0F2E] border border-[#D4ADFC] dark:border-[#4A1F7A] text-[#6917AF] dark:text-[#D7B5F5] py-3 px-4 rounded-lg">
-          <Loader2 className="animate-spin shrink-0" size={16} />
-          <p className="text-xs font-medium">
-            Confirming on-chain&hellip; your ticket is reserved.
-          </p>
-        </div>
-      )}
-
       <div className="flex justify-between items-center mb-5">
         <h2 className="text-[32px] font-bold text-[#1F1F1F] dark:text-white">
           You&apos;re In!
@@ -79,7 +72,6 @@ export const PurchasedStage: FC<PurchasedStageProps> = ({
       <div className="flex gap-5">
         <button
           onClick={onViewAccessCode}
-          disabled={isConfirming}
           className="flex-1 py-4 bg-[#6917AF] text-white rounded-full flex items-center justify-center gap-3 hover:bg-[#5A1396] transition-all shadow-md active:scale-[0.98] disabled:opacity-60 disabled:cursor-not-allowed"
         >
           <Image src="/qr-code-01.png" alt="QR Code" width={24} height={24} />
@@ -88,7 +80,6 @@ export const PurchasedStage: FC<PurchasedStageProps> = ({
 
         <button
           onClick={onCancelRegistration}
-          disabled={isConfirming}
           className="flex-1 py-4 border-2 border-[#6917AF] text-[#6917AF] dark:text-[#E0E0E0] rounded-full font-bold flex items-center justify-center gap-3 hover:bg-[#6917AF]/5 transition-all outline-none active:scale-[0.98] disabled:opacity-60 disabled:cursor-not-allowed"
         >
           <Image

--- a/app/components/explore/EventCheckout/TicketInfo.tsx
+++ b/app/components/explore/EventCheckout/TicketInfo.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { FC, useState, useEffect, useRef, useCallback } from "react";
-import { Check, Loader2, CheckCircle2 } from "lucide-react";
+import { FC, useState } from "react";
+import { Check, Loader2, CheckCircle2, WifiOff } from "lucide-react";
 import { useSimulatedAvailability } from "@/lib/hooks/useSimulatedAvailability";
 import {
   DangerIcon,
@@ -18,17 +18,10 @@ import { loadWalletSDK, preloadWalletSDK, WalletLoadState } from "@/lib/walletSd
 import { useUserSessionSync } from "@/lib/user-session-sync";
 import { useCooldown } from "@/hooks/useCooldown";
 import { CooldownMessage } from "@/app/components/AntiSpam/CooldownMessage";
-import { TransactionStatusBanner } from "@/components/TransactionStatusBanner";
-import type { TransactionStatus } from "@/hooks/useTransactionStatus";
+import { TransactionStatusBanner, type BannerStatus } from "@/components/TransactionStatusBanner";
+import { useTransactionStatus, type TransactionStatus } from "@/hooks/useTransactionStatus";
 
 type PaymentStatus = "idle" | "processing" | "failed";
-
-interface TxState {
-  status: TransactionStatus;
-  txHash: string | null;
-  error: string | null;
-  attempts: number;
-}
 
 interface TicketInfoProps {
   eventId: string;
@@ -44,17 +37,39 @@ interface TicketInfoProps {
   onResetPayment?: () => void;
 }
 
-const POLL_INTERVAL_MS = 3000;
-const MAX_POLL_ATTEMPTS = 20;
+/**
+ * Single derived status driving the one shared banner, in priority order, so
+ * a chain success and a reconcile failure can never render two contradictory
+ * messages at once.
+ */
+function getBannerStatus(params: {
+  walletError: string | null;
+  chainStatus: TransactionStatus;
+  hasPaymentFailed: boolean;
+}): BannerStatus {
+  const { walletError, chainStatus, hasPaymentFailed } = params;
 
-async function fetchTxStatus(
-  txHash: string
-): Promise<{ status: TransactionStatus; error?: string }> {
-  const res = await fetch(`/api/transactions/${txHash}/status`);
-  if (!res.ok) throw new Error(`HTTP ${res.status}`);
-  return res.json();
+  if (walletError) return "wallet_error";
+  if (chainStatus === "failed") return "failed";
+  if (chainStatus === "confirmed" && hasPaymentFailed) return "reconcile_failed";
+  // Any on-chain confirmation still in checkout means we're finalizing (or
+  // about to). Never show the green "Ticket confirmed!" success here — that
+  // would flash between poll confirm and paymentStatus flipping to
+  // "processing", and the real success UI is PurchasedStage.
+  if (chainStatus === "confirmed") return "reconciling";
+  if (chainStatus === "stalled") return "stalled";
+  if (chainStatus === "pending") return "pending";
+  // Pre-flight failure (e.g. sold out) — no tx was ever attempted.
+  if (hasPaymentFailed) return "failed";
+  return "idle";
 }
 
+/**
+ * Ticket purchase panel for an event. Drives the paid (wallet + on-chain
+ * polling) and free (anonymous) flows, coordinates reconciliation via
+ * `onStatusChange`, and renders a single derived {@link TransactionStatusBanner}
+ * so wallet, chain, and reconcile states never contradict each other.
+ */
 export const TicketInfo: FC<TicketInfoProps> = ({
   eventId,
   ticketTypes,
@@ -81,20 +96,23 @@ export const TicketInfo: FC<TicketInfoProps> = ({
     error: null,
   });
 
-  const [txState, setTxState] = useState<TxState>({
-    status: "idle",
-    txHash: null,
-    error: null,
-    attempts: 0,
+  // Chain-level polling lives in the shared hook; reconciliation (the backend
+  // finalize step) is owned by the parent (onStatusChange) and layered on top
+  // via paymentStatus/paymentError below — see `bannerStatus`.
+  const {
+    status: chainStatus,
+    txHash: chainTxHash,
+    error: chainError,
+    startTracking,
+    reset: resetChainTracking,
+    checkConnection,
+  } = useTransactionStatus({
+    onConfirmed: () => {
+      void onStatusChange?.({ isConfirmed: true, isPaid });
+    },
   });
 
   const { isOnCooldown, remainingSeconds, startCooldown } = useCooldown({ duration: 8 });
-
-  const intervalRef = useRef<NodeJS.Timeout | null>(null);
-
-  const stopPolling = () => {
-    if (intervalRef.current) clearInterval(intervalRef.current);
-  };
 
   const decrementQuantity = () => {
     if (quantity > 1) {
@@ -114,74 +132,23 @@ export const TicketInfo: FC<TicketInfoProps> = ({
   // which we handle safely by checking inside the handlers and on render.
   const clampedQuantity = liveSlotsLeft > 0 ? Math.min(quantity, liveSlotsLeft) : quantity;
 
-  const poll = async (txHash: string) => {
-    try {
-      const result = await fetchTxStatus(txHash);
-
-      setTxState((s) => {
-        const nextAttempts = s.attempts + 1;
-
-        if (nextAttempts >= MAX_POLL_ATTEMPTS && result.status === "pending") {
-          stopPolling();
-          return {
-            ...s,
-            status: "failed" as TransactionStatus,
-            error: "Transaction is taking longer than expected. Please check your wallet and try again.",
-            attempts: nextAttempts,
-          };
-        }
-
-        return {
-          ...s,
-          status: result.status,
-          error: result.error ?? null,
-          attempts: nextAttempts,
-        };
-      });
-
-      if (result.status === "confirmed") {
-        stopPolling();
-        await onStatusChange?.({
-          isConfirmed: true,
-          isPaid,
-        });
-      } else if (result.status === "failed") {
-        stopPolling();
-      }
-    } catch {
-      setTxState((s) => {
-        const nextAttempts = s.attempts + 1;
-        if (nextAttempts >= MAX_POLL_ATTEMPTS) {
-          stopPolling();
-          return {
-            ...s,
-            status: "failed" as TransactionStatus,
-            error: "Unable to verify transaction. Please check your wallet and try again.",
-            attempts: nextAttempts,
-          };
-        }
-        return { ...s, attempts: nextAttempts };
-      });
-    }
-  };
-
-  const startTracking = (txHash: string) => {
-    setTxState({ status: "pending", txHash, error: null, attempts: 0 });
-    poll(txHash);
-    intervalRef.current = setInterval(() => poll(txHash), POLL_INTERVAL_MS);
-  };
-
-  useEffect(() => () => stopPolling(), []);
-
   const handlePrimaryClick = async () => {
-    if (isProcessingPayment || txState.status === "pending" || isOnCooldown) return;
+    if (isProcessingPayment || chainStatus === "pending" || chainStatus === "stalled" || isOnCooldown) return;
+
+    // The on-chain payment already succeeded and only the backend reconcile
+    // step failed — retry reconciliation directly. Do NOT re-trigger a new
+    // wallet signature here, or the user could end up paying twice.
+    if (hasPaymentFailed && chainStatus === "confirmed") {
+      void onStatusChange?.({ isConfirmed: true, isPaid });
+      return;
+    }
+
+    if (isSoldOut) return;
 
     startCooldown();
 
     setWalletState({ isLoading: true, error: null });
-    setTxState({ status: "idle", txHash: null, error: null, attempts: 0 });
-
-    if (isSoldOut || isProcessingPayment) return;
+    resetChainTracking();
 
     try {
       if (isPaid) {
@@ -190,7 +157,13 @@ export const TicketInfo: FC<TicketInfoProps> = ({
         setWalletState({ isLoading: false, error: null });
         startTracking(txHash);
       } else {
-        await onStatusChange?.({ isConfirmed: true, isPaid: false });
+        const result = await onStatusChange?.({ isConfirmed: true, isPaid: false });
+        if (result && !result.ok) {
+          // Parent owns paymentError / failed banner — don't pretend anonymous
+          // mode succeeded when reconcile rejected the attempt.
+          setWalletState({ isLoading: false, error: null });
+          return;
+        }
         setAnonymousBrowsing(true);
         setWalletState({ isLoading: false, error: null });
       }
@@ -205,18 +178,18 @@ export const TicketInfo: FC<TicketInfoProps> = ({
     }
   };
 
-  const handleRetry = useCallback(() => {
-    stopPolling();
-    setTxState({ status: "idle", txHash: null, error: null, attempts: 0 });
+  const handleRetry = () => {
+    resetChainTracking();
     setWalletState({ isLoading: false, error: null });
     onResetPayment?.();
-  }, [onResetPayment]);
+  };
 
   const isButtonDisabled =
     walletState.isLoading ||
     isProcessingPayment ||
-    txState.status === "pending" ||
-    txState.status === "confirmed" ||
+    chainStatus === "pending" ||
+    chainStatus === "stalled" ||
+    (chainStatus === "confirmed" && paymentStatus !== "failed") ||
     isOnCooldown;
 
   const buttonLabel = () => {
@@ -236,7 +209,7 @@ export const TicketInfo: FC<TicketInfoProps> = ({
         </>
       );
 
-    if (txState.status === "pending")
+    if (chainStatus === "pending")
       return (
         <>
           <Loader2 className="animate-spin" size={20} />
@@ -244,11 +217,35 @@ export const TicketInfo: FC<TicketInfoProps> = ({
         </>
       );
 
-    if (txState.status === "confirmed")
+    if (chainStatus === "stalled")
+      return (
+        <>
+          <WifiOff size={20} />
+          Connection issue…
+        </>
+      );
+
+    if (chainStatus === "confirmed" && hasPaymentFailed)
+      return (
+        <>
+          <PasswordProtectedShield />
+          Retry Confirmation
+        </>
+      );
+
+    if (chainStatus === "confirmed")
       return (
         <>
           <CheckCircle2 size={20} />
           Ticket Confirmed
+        </>
+      );
+
+    if (chainStatus === "failed")
+      return (
+        <>
+          <PasswordProtectedShield />
+          Retry Payment
         </>
       );
 
@@ -281,6 +278,28 @@ export const TicketInfo: FC<TicketInfoProps> = ({
       </>
     );
   };
+
+  const bannerStatus = getBannerStatus({
+    walletError: walletState.error,
+    chainStatus,
+    hasPaymentFailed,
+  });
+
+  const bannerError =
+    bannerStatus === "wallet_error"
+      ? walletState.error
+      : bannerStatus === "reconcile_failed" || (bannerStatus === "failed" && chainStatus === "idle")
+        ? paymentError
+        : chainError;
+
+  const bannerRetry =
+    bannerStatus === "wallet_error"
+      ? (isOnCooldown ? undefined : handlePrimaryClick)
+      : bannerStatus === "reconcile_failed"
+        ? () => void onStatusChange?.({ isConfirmed: true, isPaid })
+        : bannerStatus === "failed"
+          ? handleRetry
+          : undefined;
 
   return (
     <div className="p-8 border border-[#E9E9E9] rounded-xl space-y-6 dark:border-[#232323] w-full">
@@ -399,64 +418,57 @@ export const TicketInfo: FC<TicketInfoProps> = ({
               ))}
             </div>
           </div>
-
-          {/* Tx banner */}
-          {txState.status !== "idle" && (
-            <TransactionStatusBanner
-              status={txState.status}
-              txHash={txState.txHash}
-              error={txState.error}
-              onRetry={txState.status === "failed" ? handleRetry : undefined}
-            />
-          )}
-
-          {/* Cooldown message */}
-          <CooldownMessage remainingSeconds={remainingSeconds} />
-
-          {/* Payment error from parent (e.g. sold out, reconcile failure) */}
-          {hasPaymentFailed && txState.status === "idle" && (
-            <div className="bg-[#FFF2F2] border border-[#FBCACA] text-[#B42318] py-3 px-5 rounded-lg">
-              <p className="text-xs font-medium">
-                {paymentError ?? "Payment failed. Please retry."}
-              </p>
-            </div>
-          )}
-
-          <div className="bg-[#F2FFF2] dark:bg-[#131313] dark:text-[#0BD330] text-[#0ABA2A] py-3 px-5 gap-4 flex">
-            <DangerIcon />
-            <p className="text-xs font-medium">Secure & Instant Payment</p>
-          </div>
-
-          <div>
-            <button
-              type="button"
-              disabled={isSoldOut || isProcessingPayment || walletState.isLoading || isButtonDisabled}
-              onClick={handlePrimaryClick}
-              onMouseEnter={isSoldOut ? undefined : preloadWalletSDK}
-              onFocus={isSoldOut ? undefined : preloadWalletSDK}
-              className={
-                isSoldOut
-                  ? "py-4 px-6 flex w-full items-center justify-center font-bold rounded-full gap-3 duration-200 ease-in-out transition bg-[#E4E5E6] text-[#98A2B3] cursor-not-allowed dark:bg-[#232323] dark:text-[#667085]"
-                  : `py-4 px-6 bg-[#6917AF] text-[#FCFDFD] flex w-full items-center justify-center font-bold rounded-full gap-3 duration-200 ease-in-out transition dark:bg-[#751AC6] dark:text-[#0F0F0F] dark:hover:bg-[#751AC6]/95 disabled:opacity-60 disabled:cursor-not-allowed ${!(isProcessingPayment || walletState.isLoading)
-                    ? "cursor-pointer hover:bg-[#6917AF]/95"
-                    : ""
-                    }`
-              }
-            >
-              {isSoldOut ? (
-                <>
-                  <PasswordProtectedShield />
-                  <span>Sold out</span>
-                </>
-              ) : (
-                <>{buttonLabel()}</>
-              )}
-            </button>
-            {walletState.error && (
-              <p className="mt-2 text-sm text-red-500">{walletState.error}</p>
-            )}
-          </div>
         </fieldset>
+
+        {/* Unified failure/status banner — covers wallet errors, chain
+            delays, stalled connections, on-chain failures, and partial
+            (on-chain-ok-but-not-reconciled) confirmations in one place.
+            Kept outside the fieldset above: its retry/check-connection
+            actions must stay usable even if the event sells out while a
+            payment the user already made is still being reconciled. */}
+        <TransactionStatusBanner
+          status={bannerStatus}
+          txHash={chainTxHash}
+          error={bannerError}
+          retryLabel={bannerStatus === "reconcile_failed" ? "Retry Confirmation" : undefined}
+          onRetry={bannerRetry}
+          onCheckConnection={bannerStatus === "stalled" ? checkConnection : undefined}
+        />
+
+        {/* Cooldown message */}
+        <CooldownMessage remainingSeconds={remainingSeconds} />
+
+        <div className="bg-[#F2FFF2] dark:bg-[#131313] dark:text-[#0BD330] text-[#0ABA2A] py-3 px-5 gap-4 flex">
+          <DangerIcon />
+          <p className="text-xs font-medium">Secure & Instant Payment</p>
+        </div>
+
+        <div>
+          <button
+            type="button"
+            disabled={isSoldOut || isProcessingPayment || walletState.isLoading || isButtonDisabled}
+            onClick={handlePrimaryClick}
+            onMouseEnter={isSoldOut ? undefined : preloadWalletSDK}
+            onFocus={isSoldOut ? undefined : preloadWalletSDK}
+            className={
+              isSoldOut
+                ? "py-4 px-6 flex w-full items-center justify-center font-bold rounded-full gap-3 duration-200 ease-in-out transition bg-[#E4E5E6] text-[#98A2B3] cursor-not-allowed dark:bg-[#232323] dark:text-[#667085]"
+                : `py-4 px-6 bg-[#6917AF] text-[#FCFDFD] flex w-full items-center justify-center font-bold rounded-full gap-3 duration-200 ease-in-out transition dark:bg-[#751AC6] dark:text-[#0F0F0F] dark:hover:bg-[#751AC6]/95 disabled:opacity-60 disabled:cursor-not-allowed ${!(isProcessingPayment || walletState.isLoading)
+                  ? "cursor-pointer hover:bg-[#6917AF]/95"
+                  : ""
+                  }`
+            }
+          >
+            {isSoldOut ? (
+              <>
+                <PasswordProtectedShield />
+                <span>Sold out</span>
+              </>
+            ) : (
+              <>{buttonLabel()}</>
+            )}
+          </button>
+        </div>
       </form>
     </div>
   );

--- a/app/components/explore/EventDetailClient.tsx
+++ b/app/components/explore/EventDetailClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { PurchasedStage } from "./EventCheckout/PurchasedStage";
 import { TicketCancellationModal } from "../TicketCancellationModal";
 import { EventDetailCard } from "./EventCheckout/eventDetailsCard";
@@ -38,6 +38,11 @@ export default function EventDetailClient({ event }: EventDetailClientProps) {
   const [paymentStatus, setPaymentStatus] = useState<PaymentStatus>("idle");
   const [paymentError, setPaymentError] = useState<string | null>(null);
   const [attemptId, setAttemptId] = useState<string | null>(null);
+  // Synchronous mutex for the reconcile call. `paymentStatus` only updates on
+  // the next render, so two calls firing in the same tick (e.g. a button click
+  // racing the poll's onConfirmed) would both read "idle" and both POST. A ref
+  // flips immediately, so the second caller is rejected before it can submit.
+  const inFlightRef = useRef(false);
 
   // Only switch to the purchased view once the ticket is *actually*
   // reconciled. Switching away from TicketInfo any earlier (e.g. as soon as
@@ -137,7 +142,7 @@ export default function EventDetailClient({ event }: EventDetailClientProps) {
     isConfirmed: boolean;
     isPaid: boolean;
   }): Promise<PaymentAttemptResult> => {
-    if (paymentStatus === "processing") {
+    if (inFlightRef.current) {
       return { ok: false, error: "Payment already in progress." };
     }
 
@@ -152,6 +157,7 @@ export default function EventDetailClient({ event }: EventDetailClientProps) {
       return { ok: false, error: "Tickets are sold out for this event." };
     }
 
+    inFlightRef.current = true;
     const nextAttemptId = attemptId ?? createAttemptId();
     setAttemptId(nextAttemptId);
     setPaymentStatus("processing");
@@ -169,7 +175,6 @@ export default function EventDetailClient({ event }: EventDetailClientProps) {
 
       setIsConfirmed(status.isConfirmed);
       setIsPaid(status.isPaid);
-      setAttemptId(null);
       resetPaymentAttemptState();
       return { ok: true };
     } catch (error) {
@@ -182,6 +187,8 @@ export default function EventDetailClient({ event }: EventDetailClientProps) {
           : "Payment failed. Please try again.";
       setPaymentError(message);
       return { ok: false, error: message };
+    } finally {
+      inFlightRef.current = false;
     }
   };
 
@@ -236,7 +243,6 @@ export default function EventDetailClient({ event }: EventDetailClientProps) {
         onConfirm={(_, __, updatedState) => {
           setIsConfirmed(updatedState.isConfirmed);
           setIsPaid(updatedState.isPaid);
-          setAttemptId(null);
           resetPaymentAttemptState();
           setShowCancelModal(false);
         }}

--- a/app/components/explore/EventDetailClient.tsx
+++ b/app/components/explore/EventDetailClient.tsx
@@ -39,18 +39,32 @@ export default function EventDetailClient({ event }: EventDetailClientProps) {
   const [paymentError, setPaymentError] = useState<string | null>(null);
   const [attemptId, setAttemptId] = useState<string | null>(null);
 
-  const [isOptimistic, setIsOptimistic] = useState(false);
+  // Only switch to the purchased view once the ticket is *actually*
+  // reconciled. Switching away from TicketInfo any earlier (e.g. as soon as
+  // the on-chain tx confirms) would unmount it mid-reconcile, wiping the
+  // chain status/txHash it needs to show a correct "reconcile failed —
+  // don't double-pay" message and to retry reconciliation without
+  // re-triggering a new wallet payment.
+  //
+  // Gate on the event's own paid-ness rather than the reconciled `isPaid`
+  // flag: free events reconcile with isPaid=false (see the anonymous path in
+  // TicketInfo), so requiring isPaid here would strand free-event purchases
+  // on the checkout view forever.
+  const isPurchased = isConfirmed && (event.isPaid ? isPaid : true);
 
-  const isReallyPurchased = isConfirmed && isPaid;
-  const isPurchased = isOptimistic || isReallyPurchased;
-
+  /** Clears any in-progress/failed payment attempt back to a clean idle state. */
   const resetPaymentAttemptState = () => {
     setPaymentStatus("idle");
     setPaymentError(null);
-    setIsOptimistic(false);
     setAttemptId(null);
   };
 
+  /**
+   * Generates a stable idempotency key for a purchase attempt. The same key is
+   * reused across retries so the reconcile endpoint can dedupe them into one
+   * ticket. Falls back to a timestamp+random id where `crypto.randomUUID` is
+   * unavailable.
+   */
   const createAttemptId = () => {
     if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
       return crypto.randomUUID();
@@ -58,6 +72,12 @@ export default function EventDetailClient({ event }: EventDetailClientProps) {
     return `attempt_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`;
   };
 
+  /**
+   * Calls the reconcile endpoint to finalize a confirmed payment into a ticket.
+   * Normalizes HTTP errors, rejected payloads, and network failures into a
+   * single `{ ok, error }` result so callers don't have to branch on transport
+   * details.
+   */
   const reconcileWithBackend = async (
     nextAttemptId: string,
     status: { isConfirmed: boolean; isPaid: boolean },
@@ -106,6 +126,13 @@ export default function EventDetailClient({ event }: EventDetailClientProps) {
     }
   };
 
+  /**
+   * Entry point passed to {@link TicketInfo} as `onStatusChange`. Guards against
+   * concurrent/duplicate attempts and sold-out events, then drives the
+   * reconcile step, updating `paymentStatus`/`paymentError` so the checkout
+   * banner reflects the outcome. Safe to call again on retry — it reuses the
+   * existing `attemptId`.
+   */
   const handleStatusChange = async (status: {
     isConfirmed: boolean;
     isPaid: boolean;
@@ -114,13 +141,12 @@ export default function EventDetailClient({ event }: EventDetailClientProps) {
       return { ok: false, error: "Payment already in progress." };
     }
 
-    if (isReallyPurchased) {
+    if (isPurchased) {
       return { ok: false, error: "Payment already completed." };
     }
 
     if (event.slotsLeft < 1) {
       setAttemptId(null);
-      setIsOptimistic(false);
       setPaymentStatus("failed");
       setPaymentError("Tickets are sold out for this event.");
       return { ok: false, error: "Tickets are sold out for this event." };
@@ -128,7 +154,6 @@ export default function EventDetailClient({ event }: EventDetailClientProps) {
 
     const nextAttemptId = attemptId ?? createAttemptId();
     setAttemptId(nextAttemptId);
-    setIsOptimistic(true);
     setPaymentStatus("processing");
     setPaymentError(null);
 
@@ -144,12 +169,10 @@ export default function EventDetailClient({ event }: EventDetailClientProps) {
 
       setIsConfirmed(status.isConfirmed);
       setIsPaid(status.isPaid);
-      setIsOptimistic(false);
       setAttemptId(null);
       resetPaymentAttemptState();
       return { ok: true };
     } catch (error) {
-      setIsOptimistic(false);
       setIsConfirmed(false);
       setIsPaid(false);
       setPaymentStatus("failed");
@@ -198,7 +221,6 @@ export default function EventDetailClient({ event }: EventDetailClientProps) {
       ) : (
         <div className="max-w-[550px] mx-auto py-10">
           <PurchasedStage
-            isConfirming={isOptimistic && !isReallyPurchased}
             onCancelRegistration={() => setShowCancelModal(true)}
           />
         </div>
@@ -214,7 +236,6 @@ export default function EventDetailClient({ event }: EventDetailClientProps) {
         onConfirm={(_, __, updatedState) => {
           setIsConfirmed(updatedState.isConfirmed);
           setIsPaid(updatedState.isPaid);
-          setIsOptimistic(false);
           setAttemptId(null);
           resetPaymentAttemptState();
           setShowCancelModal(false);

--- a/app/components/organizer/ConnectWalletPrompt.tsx
+++ b/app/components/organizer/ConnectWalletPrompt.tsx
@@ -6,7 +6,13 @@ import { useState } from "react";
 import { trackAnalyticsEvent } from "@/lib/privacyAnalytics";
 import { loadWalletSDK, preloadWalletSDK, WalletLoadState } from "@/lib/walletSdk";
 import { useUserSessionSync } from "@/lib/user-session-sync";
+import { TransactionStatusBanner } from "@/components/TransactionStatusBanner";
 
+/**
+ * Organizer-facing prompt to connect a wallet for receiving payments. Surfaces
+ * connect errors through the shared {@link TransactionStatusBanner} so wallet
+ * failures look consistent with the attendee checkout flow.
+ */
 export default function ConnectWalletPrompt() {
   const [walletState, setWalletState] = useState<WalletLoadState>({
     isLoading: false,
@@ -14,6 +20,7 @@ export default function ConnectWalletPrompt() {
   });
   const { walletConnected, setWalletConnected } = useUserSessionSync();
 
+  /** Loads the wallet SDK and reflects the outcome in local wallet state. */
   async function handleConnectWallet() {
     trackAnalyticsEvent("wallet_connect_cta_clicked", { source: "organizer_prompt" });
     setWalletState({ isLoading: true, error: null });
@@ -70,7 +77,13 @@ export default function ConnectWalletPrompt() {
             )}
           </button>
           {walletState.error && (
-            <p className="mt-2 text-sm text-red-500">{walletState.error}</p>
+            <TransactionStatusBanner
+              status="wallet_error"
+              error={walletState.error}
+              hint="Make sure your wallet extension is unlocked, then try again."
+              onRetry={handleConnectWallet}
+              className="mt-3 text-left"
+            />
           )}
         </div>
       </div>

--- a/app/components/organizer/ConnectWalletPrompt.tsx
+++ b/app/components/organizer/ConnectWalletPrompt.tsx
@@ -76,15 +76,17 @@ export default function ConnectWalletPrompt() {
               </>
             )}
           </button>
-          {walletState.error && (
-            <TransactionStatusBanner
-              status="wallet_error"
-              error={walletState.error}
-              hint="Make sure your wallet extension is unlocked, then try again."
-              onRetry={handleConnectWallet}
-              className="mt-3 text-left"
-            />
-          )}
+          {/* Rendered unconditionally (idle collapses to nothing) so the
+              banner's live region is already observed when the first error
+              appears — mounting it only on error would risk a missed
+              screen-reader announcement. */}
+          <TransactionStatusBanner
+            status={walletState.error ? "wallet_error" : "idle"}
+            error={walletState.error}
+            hint="Make sure your wallet extension is unlocked, then try again."
+            onRetry={handleConnectWallet}
+            className="mt-3 text-left"
+          />
         </div>
       </div>
     </div>

--- a/components/TransactionStatusBanner.tsx
+++ b/components/TransactionStatusBanner.tsx
@@ -1,22 +1,46 @@
 "use client"
 
 import React from "react"
-import { CheckCircle2, XCircle, Loader2, RotateCcw } from "lucide-react"
+import {
+  CheckCircle2,
+  XCircle,
+  Loader2,
+  RotateCcw,
+  WifiOff,
+  Wallet,
+  ShieldCheck,
+} from "lucide-react"
 import { cn } from "@/lib/utils"
 import type { TransactionStatus } from "@/hooks/useTransactionStatus"
 import Link from "next/link";
 
+/**
+ * Extends the on-chain polling states from useTransactionStatus with two
+ * states that live above it: "reconciling" (on-chain confirmed, backend
+ * finalization still in flight) and "reconcile_failed" (on-chain confirmed,
+ * backend rejected/errored — funds already moved, don't double-pay) and
+ * "wallet_error" (wallet connect/signing failed before any tx exists).
+ */
+export type BannerStatus = TransactionStatus | "reconciling" | "reconcile_failed" | "wallet_error"
+
 export interface TransactionStatusBannerProps {
-  status: TransactionStatus
+  status: BannerStatus
   txHash?: string | null
   error?: string | null
   pendingMessage?: string
   confirmedMessage?: string
   failedMessage?: string
+  /** Overrides the default reassurance/caution line shown under the message. */
+  hint?: string
+  /** Label for the primary retry action. Defaults to a status-appropriate label. */
+  retryLabel?: string
   onRetry?: () => void
+  /** Shown alongside onRetry for "stalled" — a lighter-weight re-check action. */
+  onCheckConnection?: () => void
+  explorerBaseUrl?: string
+  explorerLabel?: string
   className?: string
 }
-
 
 const CONFIG = {
   idle: null,
@@ -26,7 +50,20 @@ const CONFIG = {
     wrapperClass:
       "bg-[#F5EEFF] dark:bg-[#1C0F2E] border-[#D4ADFC] dark:border-[#4A1F7A]",
     textClass: "text-[#6917AF] dark:text-[#D7B5F5]",
-    label: "Pending",
+    heading: "Transaction Pending",
+    role: "status" as const,
+    // Tx already submitted — do not encourage another payment while we wait.
+    hint: "Please wait — don't submit another payment while this confirms.",
+  },
+  stalled: {
+    icon: WifiOff,
+    iconClass: "text-amber-600 dark:text-amber-400",
+    wrapperClass:
+      "bg-amber-50 dark:bg-amber-950/30 border-amber-200 dark:border-amber-800/40",
+    textClass: "text-amber-800 dark:text-amber-300",
+    heading: "Network Issue Detected",
+    role: "alert" as const,
+    hint: "Safe to retry — no assets have been deducted. You can keep waiting or check your connection.",
   },
   confirmed: {
     icon: CheckCircle2,
@@ -34,7 +71,19 @@ const CONFIG = {
     wrapperClass:
       "bg-[#ECFDF3] dark:bg-[#052E16] border-[#6CE9A6] dark:border-[#166534]",
     textClass: "text-[#027A48] dark:text-[#4ADE80]",
-    label: "Confirmed",
+    heading: "Transaction Confirmed",
+    role: "status" as const,
+    hint: undefined,
+  },
+  reconciling: {
+    icon: Loader2,
+    iconClass: "animate-spin text-blue-600 dark:text-blue-400",
+    wrapperClass:
+      "bg-blue-50 dark:bg-blue-950/30 border-blue-200 dark:border-blue-800/40",
+    textClass: "text-blue-700 dark:text-blue-300",
+    heading: "Finalizing Your Ticket",
+    role: "status" as const,
+    hint: "Your payment is confirmed on-chain. Please don't submit another payment while we finalize your ticket.",
   },
   failed: {
     icon: XCircle,
@@ -42,14 +91,53 @@ const CONFIG = {
     wrapperClass:
       "bg-[#FEF3F2] dark:bg-[#2D0B09] border-[#FDA29B] dark:border-[#7F1D1D]",
     textClass: "text-[#B42318] dark:text-[#F87171]",
-    label: "Failed",
+    heading: "Transaction Failed",
+    role: "alert" as const,
+    hint: "Safe to retry — no funds were deducted from this attempt.",
+  },
+  reconcile_failed: {
+    icon: XCircle,
+    iconClass: "text-[#D92D20]",
+    wrapperClass:
+      "bg-[#FEF3F2] dark:bg-[#2D0B09] border-[#FDA29B] dark:border-[#7F1D1D]",
+    textClass: "text-[#B42318] dark:text-[#F87171]",
+    heading: "Confirmation Failed",
+    role: "alert" as const,
+    hint: "Don't submit another payment — retrying just re-checks your existing one.",
+  },
+  wallet_error: {
+    icon: Wallet,
+    iconClass: "text-[#D92D20]",
+    wrapperClass:
+      "bg-[#FEF3F2] dark:bg-[#2D0B09] border-[#FDA29B] dark:border-[#7F1D1D]",
+    textClass: "text-[#B42318] dark:text-[#F87171]",
+    heading: "Wallet Error",
+    role: "alert" as const,
+    hint: "Check your wallet before retrying — avoid approving another payment if one is already pending there.",
   },
 } as const
 
-function explorerUrl(txHash: string) {
-  return `https://solscan.io/tx/${txHash}`
+const DEFAULT_MESSAGES: Partial<Record<BannerStatus, string>> = {
+  stalled: "The transaction status is currently unknown due to a connection problem. It usually resolves on its own.",
+  reconciling: "Payment confirmed on-chain. Finalizing your ticket…",
+  reconcile_failed: "Your payment was confirmed on-chain, but we couldn't finalize your ticket.",
+  wallet_error: "Failed to load wallet. Please try again.",
 }
 
+// Allows non-production environments (e.g. testnet) to point at the right
+// explorer without every call site having to pass explorerBaseUrl.
+const DEFAULT_EXPLORER_BASE_URL =
+  process.env.NEXT_PUBLIC_EXPLORER_BASE_URL ?? "https://stellar.expert/explorer/public/tx"
+const DEFAULT_EXPLORER_LABEL = "View on Stellar Expert"
+
+/**
+ * Unified status/failure banner for the checkout and wallet flows. Renders one
+ * message per {@link BannerStatus} (pending, stalled, confirmed, reconciling,
+ * failed, reconcile_failed, wallet_error) with status-appropriate copy, an
+ * optional explorer link, a reassurance/caution hint, and retry /
+ * check-connection actions. The live-region wrapper stays mounted even when
+ * idle so screen readers don't miss the first announcement.
+ */
 export function TransactionStatusBanner({
   status,
   txHash,
@@ -57,83 +145,134 @@ export function TransactionStatusBanner({
   pendingMessage = "Confirming your ticket purchase…",
   confirmedMessage = "Ticket confirmed! You're all set.",
   failedMessage,
+  hint,
+  retryLabel,
   onRetry,
+  onCheckConnection,
+  explorerBaseUrl = DEFAULT_EXPLORER_BASE_URL,
+  explorerLabel = DEFAULT_EXPLORER_LABEL,
   className,
 }: TransactionStatusBannerProps) {
   const config = CONFIG[status]
-  if (!config) return null
-
-  const Icon = config.icon
+  const Icon = config?.icon
+  const role = config?.role ?? "status"
 
   const message =
     status === "pending"
       ? pendingMessage
       : status === "confirmed"
       ? confirmedMessage
-      : (failedMessage ?? error ?? "Something went wrong. Please try again.")
+      : (failedMessage ?? error ?? DEFAULT_MESSAGES[status] ?? "Something went wrong. Please try again.")
+
+  const hintText = hint ?? config?.hint
+
+  const showExplorerLink = txHash && status !== "pending" && status !== "wallet_error"
+  const showHashPreview = txHash && status === "pending"
+  const showCheckConnection = status === "stalled" && onCheckConnection
+  const showRetry = (status === "failed" || status === "reconcile_failed" || status === "wallet_error") && onRetry
+  const showStalledRetryFallback = status === "stalled" && !onCheckConnection && onRetry
 
   return (
+    // The live-region wrapper is always mounted (even for "idle", when it's
+    // empty and visually collapses to nothing) so screen readers are already
+    // observing it before the first status text appears — a freshly-inserted
+    // role="status"/"alert" element can have its initial announcement missed.
     <div
-      role="status"
-      aria-live="polite"
+      role={role}
+      aria-live={role === "status" ? "polite" : undefined}
       className={cn(
-        "flex items-start gap-3 rounded-xl border px-4 py-3 transition-all duration-300",
-        config.wrapperClass,
+        "flex items-start gap-3 transition-all duration-300",
+        config && "rounded-xl border px-4 py-3",
+        config?.wrapperClass,
         className
       )}
     >
-      {/* Icon */}
-      <Icon className={cn("mt-0.5 size-5 shrink-0", config.iconClass)} />
+      {config && Icon && (
+        <>
+          {/* Icon */}
+          <Icon aria-hidden="true" className={cn("mt-0.5 size-5 shrink-0", config.iconClass)} />
 
-      {/* Body */}
-      <div className="flex-1 min-w-0 space-y-0.5">
-        <div className="flex items-center justify-between gap-2">
-          <p className={cn("text-sm font-semibold", config.textClass)}>
-            Transaction {config.label}
-          </p>
-        </div>
+          {/* Body */}
+          <div className="flex-1 min-w-0 space-y-0.5">
+            <div className="flex items-center justify-between gap-2">
+              <p className={cn("text-sm font-semibold", config.textClass)}>
+                {config.heading}
+              </p>
+            </div>
 
-        <p className={cn("text-xs leading-relaxed", config.textClass, "opacity-90")}>
-          {message}
-        </p>
+            <p className={cn("text-xs leading-relaxed", config.textClass, "opacity-90")}>
+              {message}
+            </p>
 
-        {/* Explorer link — shown when we have a hash */}
-        {txHash && status !== "pending" && (
-          <Link
-            href={explorerUrl(txHash)}
-            target="_blank"
-            rel="noopener noreferrer"
-            className={cn(
-              "inline-flex items-center gap-1 text-xs underline underline-offset-2 mt-1",
-              config.textClass
+            {/* Explorer link — shown when we have a hash */}
+            {showExplorerLink && txHash && (
+              <Link
+                href={`${explorerBaseUrl}/${txHash}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className={cn(
+                  "inline-flex items-center gap-1 text-xs underline underline-offset-2 mt-1",
+                  config.textClass
+                )}
+              >
+                {explorerLabel} ↗
+              </Link>
             )}
-          >
-            View on Solscan ↗
-          </Link>
-        )}
 
-        {/* Shortened hash shown while pending */}
-        {txHash && status === "pending" && (
-          <p className={cn("text-xs font-mono opacity-60 truncate", config.textClass)}>
-            {txHash.slice(0, 12)}…{txHash.slice(-8)}
-          </p>
-        )}
-
-        {/* Retry button on failure */}
-        {status === "failed" && onRetry && (
-          <button
-            type="button"
-            onClick={onRetry}
-            className={cn(
-              "mt-2 inline-flex items-center gap-1.5 text-xs font-semibold underline underline-offset-2",
-              config.textClass
+            {/* Shortened hash shown while pending */}
+            {showHashPreview && txHash && (
+              <p className={cn("text-xs font-mono opacity-60 truncate", config.textClass)}>
+                {txHash.slice(0, 12)}…{txHash.slice(-8)}
+              </p>
             )}
-          >
-            <RotateCcw size={12} />
-            Try again
-          </button>
-        )}
-      </div>
+
+            {/* Reassurance / caution hint, mirroring the design's "Safe to retry" note */}
+            {hintText && (
+              <div
+                className={cn(
+                  "mt-2 flex items-start gap-1.5 rounded-lg bg-black/[0.03] dark:bg-white/[0.04] px-2.5 py-1.5 text-[11px] leading-relaxed",
+                  config.textClass,
+                  "opacity-90"
+                )}
+              >
+                <ShieldCheck aria-hidden="true" className="size-3.5 shrink-0 mt-0.5" />
+                <span>{hintText}</span>
+              </div>
+            )}
+
+            {/* Actions */}
+            <div className="flex items-center gap-4 mt-2">
+              {showCheckConnection && (
+                <button
+                  type="button"
+                  onClick={onCheckConnection}
+                  className={cn(
+                    "inline-flex items-center gap-1.5 text-xs font-semibold underline underline-offset-2",
+                    config.textClass
+                  )}
+                >
+                  <RotateCcw size={12} aria-hidden="true" />
+                  Check Connection
+                </button>
+              )}
+
+              {(showRetry || showStalledRetryFallback) && (
+                <button
+                  type="button"
+                  onClick={onRetry}
+                  className={cn(
+                    "inline-flex items-center gap-1.5 text-xs font-semibold underline underline-offset-2",
+                    config.textClass
+                  )}
+                >
+                  <RotateCcw size={12} aria-hidden="true" />
+                  {retryLabel ?? "Try again"}
+                </button>
+              )}
+            </div>
+          </div>
+        </>
+      )}
     </div>
   )
 }
@@ -143,17 +282,24 @@ export interface TxStatusDotProps {
   className?: string
 }
 
+/**
+ * Compact colored-dot + label indicator for a transaction status, for use in
+ * tight spaces (lists, headers) where the full {@link TransactionStatusBanner}
+ * would be too heavy. Renders nothing while idle.
+ */
 export function TxStatusDot({ status, className }: TxStatusDotProps) {
   if (status === "idle") return null
 
   const dotClass = {
     pending: "bg-[#6917AF] animate-pulse",
+    stalled: "bg-amber-500 animate-pulse",
     confirmed: "bg-[#039855]",
     failed: "bg-[#D92D20]",
   }[status]
 
   const label = {
     pending: "Pending",
+    stalled: "Connection issue",
     confirmed: "Confirmed",
     failed: "Failed",
   }[status]

--- a/components/TransactionStatusBanner.tsx
+++ b/components/TransactionStatusBanner.tsx
@@ -12,7 +12,6 @@ import {
 } from "lucide-react"
 import { cn } from "@/lib/utils"
 import type { TransactionStatus } from "@/hooks/useTransactionStatus"
-import Link from "next/link";
 
 /**
  * Extends the on-chain polling states from useTransactionStatus with two
@@ -157,12 +156,20 @@ export function TransactionStatusBanner({
   const Icon = config?.icon
   const role = config?.role ?? "status"
 
+  const isFailureStatus =
+    status === "failed" || status === "reconcile_failed" || status === "wallet_error"
+
   const message =
     status === "pending"
       ? pendingMessage
       : status === "confirmed"
       ? confirmedMessage
-      : (failedMessage ?? error ?? DEFAULT_MESSAGES[status] ?? "Something went wrong. Please try again.")
+      : isFailureStatus
+      // Only failure statuses fall back to failedMessage/error — otherwise a
+      // lingering error from the tracking hook could render failure copy under
+      // a "Network Issue Detected" / "Finalizing" heading.
+      ? (failedMessage ?? error ?? DEFAULT_MESSAGES[status] ?? "Something went wrong. Please try again.")
+      : (DEFAULT_MESSAGES[status] ?? "")
 
   const hintText = hint ?? config?.hint
 
@@ -171,6 +178,7 @@ export function TransactionStatusBanner({
   const showCheckConnection = status === "stalled" && onCheckConnection
   const showRetry = (status === "failed" || status === "reconcile_failed" || status === "wallet_error") && onRetry
   const showStalledRetryFallback = status === "stalled" && !onCheckConnection && onRetry
+  const showActions = showCheckConnection || showRetry || showStalledRetryFallback
 
   return (
     // The live-region wrapper is always mounted (even for "idle", when it's
@@ -204,9 +212,10 @@ export function TransactionStatusBanner({
               {message}
             </p>
 
-            {/* Explorer link — shown when we have a hash */}
+            {/* Explorer link — shown when we have a hash. Plain anchor since
+                explorerBaseUrl is an external origin (no next/link benefit). */}
             {showExplorerLink && txHash && (
-              <Link
+              <a
                 href={`${explorerBaseUrl}/${txHash}`}
                 target="_blank"
                 rel="noopener noreferrer"
@@ -216,7 +225,7 @@ export function TransactionStatusBanner({
                 )}
               >
                 {explorerLabel} ↗
-              </Link>
+              </a>
             )}
 
             {/* Shortened hash shown while pending */}
@@ -240,7 +249,9 @@ export function TransactionStatusBanner({
               </div>
             )}
 
-            {/* Actions */}
+            {/* Actions — only rendered when there's at least one, so idle /
+                pending / confirmed don't emit an empty spaced row. */}
+            {showActions && (
             <div className="flex items-center gap-4 mt-2">
               {showCheckConnection && (
                 <button
@@ -270,6 +281,7 @@ export function TransactionStatusBanner({
                 </button>
               )}
             </div>
+            )}
           </div>
         </>
       )}

--- a/hooks/useTransactionStatus.ts
+++ b/hooks/useTransactionStatus.ts
@@ -66,6 +66,11 @@ export function useTransactionStatus(options: UseTransactionStatusOptions = {}) 
     // `attempts`/`consecutiveFailuresRef` and can burn the attempt budget
     // early from repeated manual clicks.
     const inFlightRef = useRef(false)
+    // Bumped by startTracking/reset/unmount. A poll captures the generation it
+    // was started for and drops its result if the generation has moved on, so a
+    // response that lands after the caller reset or started a new tx can't write
+    // stale state or fire onConfirmed/onFailed for an abandoned hash.
+    const generationRef = useRef(0)
 
     // Stable callbacks so the interval closure doesn't go stale
     const onConfirmedRef = useRef(onConfirmed)
@@ -85,8 +90,9 @@ export function useTransactionStatus(options: UseTransactionStatusOptions = {}) 
      * is terminal, times out after `maxAttempts`, and flips to "stalled" after
      * repeated network failures. Fires onConfirmed/onFailed on terminal states.
      */
-    const poll = useCallback(async (txHash: string) => {
+    const poll = useCallback(async (txHash: string, generation: number) => {
         if (inFlightRef.current) return
+        if (generation !== generationRef.current) return
         const current = stateRef.current
 
         // Guard: stop if already terminal or exceeded attempts
@@ -115,6 +121,9 @@ export function useTransactionStatus(options: UseTransactionStatusOptions = {}) 
         inFlightRef.current = true
         try {
             const result = await fetchTransactionStatus(txHash)
+            // The tracking session was reset or replaced while this was in
+            // flight — drop the result rather than clobber the new state.
+            if (generation !== generationRef.current) return
             consecutiveFailuresRef.current = 0
 
             setState((s) => ({
@@ -133,18 +142,23 @@ export function useTransactionStatus(options: UseTransactionStatusOptions = {}) 
                 onFailedRef.current?.(result.error ?? "Transaction failed")
             }
         } catch (err) {
+            if (generation !== generationRef.current) return
             // Network error — keep polling in the background, but surface a
             // "stalled" state after a couple of consecutive failures so the
-            // user isn't left staring at a silent spinner.
+            // user isn't left staring at a silent spinner. Clear any lingering
+            // error text so a prior poll's message doesn't show under the
+            // "Network Issue Detected" heading.
             consecutiveFailuresRef.current += 1
-            setState((s) => ({
-                ...s,
-                status:
+            setState((s) => {
+                const nextStalled =
                     s.status === "pending" && consecutiveFailuresRef.current >= STALL_THRESHOLD
-                        ? "stalled"
-                        : s.status,
-                attempts: s.attempts + 1,
-            }))
+                return {
+                    ...s,
+                    status: nextStalled ? "stalled" : s.status,
+                    error: nextStalled ? null : s.error,
+                    attempts: s.attempts + 1,
+                }
+            })
         } finally {
             inFlightRef.current = false
         }
@@ -157,7 +171,7 @@ export function useTransactionStatus(options: UseTransactionStatusOptions = {}) 
      */
     const checkConnection = useCallback(() => {
         const { txHash } = stateRef.current
-        if (txHash) poll(txHash)
+        if (txHash) poll(txHash, generationRef.current)
     }, [poll])
 
     /**
@@ -168,31 +182,42 @@ export function useTransactionStatus(options: UseTransactionStatusOptions = {}) 
         (txHash: string) => {
             stopPolling()
             consecutiveFailuresRef.current = 0
+            const generation = ++generationRef.current
 
-            setState({
+            const next: TransactionState = {
                 status: "pending",
                 txHash,
                 updatedAt: new Date().toISOString(),
                 error: null,
                 attempts: 0,
-            })
+            }
+            // Prime the ref synchronously (it otherwise only updates on render)
+            // so the immediate poll below sees this new tx, not the previous
+            // one's terminal state — which would short-circuit the first check.
+            stateRef.current = next
+            setState(next)
 
             // Poll immediately, then on interval
-            poll(txHash)
-            intervalRef.current = setInterval(() => poll(txHash), pollIntervalMs)
+            poll(txHash, generation)
+            intervalRef.current = setInterval(() => poll(txHash, generation), pollIntervalMs)
         },
         [poll, pollIntervalMs, stopPolling]
     )
 
-    /** Reset everything back to idle */
+    /** Reset everything back to idle, invalidating any in-flight poll. */
     const reset = useCallback(() => {
         stopPolling()
         consecutiveFailuresRef.current = 0
+        generationRef.current++
         setState(INITIAL_STATE)
     }, [stopPolling])
 
-    // Cleanup on unmount
-    useEffect(() => () => stopPolling(), [stopPolling])
+    // Cleanup on unmount — invalidate in-flight polls so they don't setState
+    // after the component is gone.
+    useEffect(() => () => {
+        generationRef.current++
+        stopPolling()
+    }, [stopPolling])
 
     return { ...state, startTracking, reset, checkConnection }
 }

--- a/hooks/useTransactionStatus.ts
+++ b/hooks/useTransactionStatus.ts
@@ -2,7 +2,10 @@
 
 import { useState, useEffect, useCallback, useRef } from "react"
 
-export type TransactionStatus = "idle" | "pending" | "confirmed" | "failed"
+export type TransactionStatus = "idle" | "pending" | "stalled" | "confirmed" | "failed"
+
+/** Consecutive network failures before we surface a "stalled" state to the user. */
+const STALL_THRESHOLD = 2
 
 export interface TransactionState {
     status: TransactionStatus
@@ -19,6 +22,7 @@ export interface UseTransactionStatusOptions {
     onFailed?: (error: string) => void
 }
 
+/** Fetches the current on-chain status for a tx hash from the status API. */
 async function fetchTransactionStatus(
     txHash: string
 ): Promise<{ status: "pending" | "confirmed" | "failed"; error?: string }> {
@@ -35,6 +39,15 @@ const INITIAL_STATE: TransactionState = {
     attempts: 0,
 }
 
+/**
+ * Polls the transaction status API for a tx hash and exposes its lifecycle
+ * (idle → pending → stalled/confirmed/failed) plus imperative controls. Handles
+ * timeout, transient-network "stalled" detection, and overlapping-request
+ * guarding so callers get a single reliable status stream.
+ *
+ * @returns the current state spread with `startTracking`, `reset`, and
+ * `checkConnection`.
+ */
 export function useTransactionStatus(options: UseTransactionStatusOptions = {}) {
     const {
         pollIntervalMs = 3_000,
@@ -47,6 +60,12 @@ export function useTransactionStatus(options: UseTransactionStatusOptions = {}) 
     const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
     const stateRef = useRef(state)
     stateRef.current = state
+    const consecutiveFailuresRef = useRef(0)
+    // Guards against the interval poll and a manual checkConnection() call
+    // overlapping — without it, concurrent requests double-increment
+    // `attempts`/`consecutiveFailuresRef` and can burn the attempt budget
+    // early from repeated manual clicks.
+    const inFlightRef = useRef(false)
 
     // Stable callbacks so the interval closure doesn't go stale
     const onConfirmedRef = useRef(onConfirmed)
@@ -61,7 +80,13 @@ export function useTransactionStatus(options: UseTransactionStatusOptions = {}) 
         }
     }, [])
 
+    /**
+     * Runs one status check: skips if a request is already in flight or the tx
+     * is terminal, times out after `maxAttempts`, and flips to "stalled" after
+     * repeated network failures. Fires onConfirmed/onFailed on terminal states.
+     */
     const poll = useCallback(async (txHash: string) => {
+        if (inFlightRef.current) return
         const current = stateRef.current
 
         // Guard: stop if already terminal or exceeded attempts
@@ -71,8 +96,11 @@ export function useTransactionStatus(options: UseTransactionStatusOptions = {}) 
             current.attempts >= maxAttempts
         ) {
             stopPolling()
-            // Mark as failed if we ran out of attempts
-            if (current.attempts >= maxAttempts && current.status === "pending") {
+            // Mark as failed if we ran out of attempts while still waiting
+            if (
+                current.attempts >= maxAttempts &&
+                (current.status === "pending" || current.status === "stalled")
+            ) {
                 setState((s) => ({
                     ...s,
                     status: "failed",
@@ -84,8 +112,10 @@ export function useTransactionStatus(options: UseTransactionStatusOptions = {}) 
             return
         }
 
+        inFlightRef.current = true
         try {
             const result = await fetchTransactionStatus(txHash)
+            consecutiveFailuresRef.current = 0
 
             setState((s) => ({
                 ...s,
@@ -103,10 +133,32 @@ export function useTransactionStatus(options: UseTransactionStatusOptions = {}) 
                 onFailedRef.current?.(result.error ?? "Transaction failed")
             }
         } catch (err) {
-            // Network error — increment attempts but keep polling
-            setState((s) => ({ ...s, attempts: s.attempts + 1 }))
+            // Network error — keep polling in the background, but surface a
+            // "stalled" state after a couple of consecutive failures so the
+            // user isn't left staring at a silent spinner.
+            consecutiveFailuresRef.current += 1
+            setState((s) => ({
+                ...s,
+                status:
+                    s.status === "pending" && consecutiveFailuresRef.current >= STALL_THRESHOLD
+                        ? "stalled"
+                        : s.status,
+                attempts: s.attempts + 1,
+            }))
+        } finally {
+            inFlightRef.current = false
         }
     }, [maxAttempts, stopPolling])
+
+    /**
+     * Fires one immediate poll without resetting the interval/attempt count.
+     * Intended for a manual "Check Connection" / "Retry Status Check" action
+     * while stalled.
+     */
+    const checkConnection = useCallback(() => {
+        const { txHash } = stateRef.current
+        if (txHash) poll(txHash)
+    }, [poll])
 
     /**
      * Call this as soon as you have a transaction hash from the wallet.
@@ -115,6 +167,7 @@ export function useTransactionStatus(options: UseTransactionStatusOptions = {}) 
     const startTracking = useCallback(
         (txHash: string) => {
             stopPolling()
+            consecutiveFailuresRef.current = 0
 
             setState({
                 status: "pending",
@@ -134,11 +187,12 @@ export function useTransactionStatus(options: UseTransactionStatusOptions = {}) 
     /** Reset everything back to idle */
     const reset = useCallback(() => {
         stopPolling()
+        consecutiveFailuresRef.current = 0
         setState(INITIAL_STATE)
     }, [stopPolling])
 
     // Cleanup on unmount
     useEffect(() => () => stopPolling(), [stopPolling])
 
-    return { ...state, startTracking, reset }
+    return { ...state, startTracking, reset, checkConnection }
 }

--- a/lib/walletSdk.ts
+++ b/lib/walletSdk.ts
@@ -57,10 +57,23 @@ export async function loadWalletSDK(): Promise<string> {
     );
     // ── END MOCK ──────────────────────────────────────────────────────────────
 
-    // Reset on failure so callers can retry
-    loadPromise.catch(() => {
-      loadPromise = null;
-    });
+    // Clear after settle so a later purchase/retry gets a fresh tx hash.
+    // Without this, every "Retry Payment" reuses the first mock hash and the
+    // status API keeps returning the previous terminal result forever.
+    //
+    // Use then(onFulfilled, onRejected) rather than finally(): finally() returns
+    // a derived promise that rejects when loading fails, and nothing consumes
+    // it, so it would surface as an unhandled rejection. Both handlers clear the
+    // singleton; the original loadPromise is still returned so callers keep
+    // seeing the real error.
+    void loadPromise.then(
+      () => {
+        loadPromise = null;
+      },
+      () => {
+        loadPromise = null;
+      },
+    );
   }
   return loadPromise;
 }

--- a/lib/walletSdk.ts
+++ b/lib/walletSdk.ts
@@ -49,12 +49,13 @@ export async function loadWalletSDK(): Promise<string> {
     // Simulates ~2 s of wallet connection + signing latency before returning
     // a fake Solana-style transaction hash. Remove this block when the real
     // SDK is wired up.
-    loadPromise = new Promise<string>((resolve) =>
+    const current = new Promise<string>((resolve) =>
       setTimeout(
         () => resolve("mock_tx_" + Math.random().toString(36).slice(2, 18)),
         2000
       )
     );
+    loadPromise = current;
     // ── END MOCK ──────────────────────────────────────────────────────────────
 
     // Clear after settle so a later purchase/retry gets a fresh tx hash.
@@ -66,12 +67,19 @@ export async function loadWalletSDK(): Promise<string> {
     // it, so it would surface as an unhandled rejection. Both handlers clear the
     // singleton; the original loadPromise is still returned so callers keep
     // seeing the real error.
-    void loadPromise.then(
+    //
+    // Guard by identity: only null out the singleton if it's still THIS load,
+    // so a settle from an earlier load can't wipe a newer in-flight one (matters
+    // once a real SDK adds awaits between creation and settle).
+    const clearIfCurrent = () => {
+      if (loadPromise === current) loadPromise = null;
+    };
+    void current.then(
       () => {
-        loadPromise = null;
+        clearIfCurrent();
       },
       () => {
-        loadPromise = null;
+        clearIfCurrent();
       },
     );
   }


### PR DESCRIPTION
## Description

Closed #164 for GrantFox

Building on the failure-state design from #91, this implements a unified UX for wallet errors, blockchain delays, and partial (on-chain-confirmed-but-not-reconciled) confirmations. While wiring the design up to the real checkout flow, I found and fixed several correctness/security issues (double-payment risk, free events never completing, and a reconcile endpoint that trusted a client-controlled flag).

### Acceptance criteria (from #164)

- [x] **Clear handling of async/blockchain states** — `useTransactionStatus` exposes `idle → pending → stalled → confirmed → failed`; `TransactionStatusBanner` adds `reconciling`, `reconcile_failed`, and `wallet_error`. Each renders distinct copy/actions.
- [x] **No user confusion during failures** — one derived `bannerStatus` (see `getBannerStatus` in `TicketInfo.tsx`) guarantees chain success and reconcile failure can never show at once; every state carries a "safe to retry" vs. "don't submit another payment" hint.
- [x] **Consistent across app** — the same `TransactionStatusBanner` is used in attendee checkout (`TicketInfo.tsx`) and organizer wallet-connect (`ConnectWalletPrompt.tsx`).
- [x] **Consistent app theme across design themes (light/dark)** — every color in `components/TransactionStatusBanner.tsx` `CONFIG` is declared as a Tailwind pair (e.g. `bg-[#FEF3F2] dark:bg-[#2D0B09]`, `text-[#B42318] dark:text-[#F87171]`), matching the app's existing token style and driven by the existing `next-themes` provider (`app/context/ThemeContext.tsx`). No new theming layer added. Verified visually in both light and dark.
- [x] **Desktop mode available** — the banner is a fluid `flex` / `rounded-xl` block with no fixed or mobile-only widths, so it flows inside the existing desktop checkout card and organizer layout. Verified at a desktop viewport in both themes.

### Changes

1. **Extended `TransactionStatusBanner`** into a shared kit — covers `pending`, `stalled`, `confirmed`, `reconciling`, `failed`, `reconcile_failed`, and `wallet_error`, each with status-appropriate copy and a "safe to retry" vs. "don't submit another payment" hint. The live-region wrapper stays mounted so screen readers don't miss the first announcement, and the explorer link is a Stellar Expert URL (overridable via `NEXT_PUBLIC_EXPLORER_BASE_URL`).
2. **Extended `useTransactionStatus`** — surfaces a `stalled` state after repeated network failures (instead of a silent spinner until timeout), adds a `checkConnection` action, and guards against overlapping polls so a manual re-check can't burn the attempt budget.
3. **Refactored `TicketInfo`** onto the shared hook with a single derived banner status, so wallet, chain, and reconcile states can never render two contradictory messages at once.
4. **Fixed a double-payment risk** — a failed backend reconcile after a successful on-chain payment now retries reconciliation directly, never a new wallet signature.
5. **Fixed free events never reaching the purchased view** — gate on the event's own paid-ness rather than the reconciled `isPaid` flag.
6. **Hardened the reconcile route** — free/paid eligibility is derived from server-side event data, so a paid event can no longer be reconciled for free by sending `isPaid: false` (returns 402); unknown events return 404.
7. **Reused the banner for organizer wallet-connect errors** (`ConnectWalletPrompt`) for consistency.
8. **Accessibility** — `role="alert"`/`role="status"` and `aria-hidden` icons per state; added JSDoc across the touched functions.

### Verification

- ✅ `npm run build` passes
- ✅ `npx tsc --noEmit` passes with no new errors
- ✅ Manually exercised in the browser (light + dark theme, desktop viewport): full happy path, forced on-chain failure, forced reconcile failure (retry calls only the reconcile endpoint — no new wallet transaction), free-event registration, and wallet-connect error on the organizer page
- ✅ Reconcile route verified via curl: free event succeeds, paid event with `isPaid:false` is rejected (402), paid event with `isPaid:true` succeeds, unknown event returns 404
- ✅ Theme + desktop: verified visually in light and dark themes at a desktop viewport (see the Acceptance criteria section above for the concrete implementation evidence)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clearer transaction lifecycle support (including stalled, reconciling, reconcile_failed, and wallet_error) with unified banner messaging.
  * Added retry and connection-check actions, plus configurable explorer links and hints.

* **Bug Fixes**
  * Improved ticket payment reconciliation for free vs paid events, including safer idempotency handling.
  * Prevented duplicate reconcile requests and improved purchase completion gating.
  * Fixed wallet SDK reload behavior after both success and failure.
  * Standardized wallet/transaction error presentation.

* **Refactor**
  * Updated checkout and organizer wallet prompts to use the shared transaction status banner, simplifying UI and polling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

