### PR TITLE
Establish test suite (Vitest/Playwright/CI) + native Stellar & Aztec wallet integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# Stellar network the wallet adapter (lib/wallet/stellarAdapter.ts) connects
+# to. "testnet" (default) or "public".
+NEXT_PUBLIC_STELLAR_NETWORK=testnet
+
+# Optional: override the default Horizon endpoint for the selected network.
+# NEXT_PUBLIC_STELLAR_HORIZON_URL=https://horizon-testnet.stellar.org
+
+# Required to offer WalletConnect as a Stellar wallet option. Create a
+# project at https://cloud.walletconnect.com to get an id. Freighter, Lobstr,
+# and xBull work without this.
+# NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,70 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  lint-and-unit:
+    name: Lint & unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Type check
+        run: npx tsc --noEmit
+
+      - name: Unit tests
+        run: npm run test -- --coverage
+
+      - name: Upload coverage
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage
+          retention-days: 14
+
+  e2e:
+    name: Playwright E2E
+    runs-on: ubuntu-latest
+    needs: lint-and-unit
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run E2E tests
+        run: npm run test:e2e
+        env:
+          CI: true
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,10 @@
 
 # testing
 /coverage
+/playwright-report
+/test-results
+/blob-report
+/playwright/.cache
 
 # next.js
 /.next/

--- a/app/api/transactions/[txHash]/status/route.ts
+++ b/app/api/transactions/[txHash]/status/route.ts
@@ -1,18 +1,50 @@
 import { NextResponse } from "next/server";
+import { Horizon } from "@stellar/stellar-sdk";
 
 type TxRecord = {
   createdAt: number;
 };
+
+type TxStatus = { status: "pending" | "confirmed" | "failed"; error?: string };
 
 const txStore = new Map<string, TxRecord>();
 
 const CONFIRMATION_DELAY_MS = 10_000;
 const FAILURE_RATE = 0.05;
 
-function getStatusForTx(hash: string): {
-  status: "pending" | "confirmed" | "failed";
-  error?: string;
-} {
+// Real Stellar transaction hashes are 64 lowercase hex characters. Anything
+// else (e.g. an anonymous/free-flow placeholder) falls back to the simulated
+// status below, which is what the demo/dev flows have always relied on.
+const STELLAR_TX_HASH_PATTERN = /^[0-9a-f]{64}$/i;
+
+const HORIZON_URL =
+  process.env.NEXT_PUBLIC_STELLAR_HORIZON_URL ??
+  (process.env.NEXT_PUBLIC_STELLAR_NETWORK === "public"
+    ? "https://horizon.stellar.org"
+    : "https://horizon-testnet.stellar.org");
+
+let horizonServer: Horizon.Server | null = null;
+function getHorizonServer(): Horizon.Server {
+  if (!horizonServer) horizonServer = new Horizon.Server(HORIZON_URL);
+  return horizonServer;
+}
+
+/** Looks up a real, submitted Stellar transaction by hash on Horizon. */
+async function getRealTxStatus(hash: string): Promise<TxStatus> {
+  try {
+    const record = await getHorizonServer().transactions().transaction(hash).call();
+    return record.successful
+      ? { status: "confirmed" }
+      : { status: "failed", error: "Transaction failed on-chain." };
+  } catch (err) {
+    // Horizon 404s until the transaction lands in a ledger — treat that (and
+    // any transient network error) as still pending rather than failed.
+    return { status: "pending", error: err instanceof Error ? err.message : undefined };
+  }
+}
+
+/** Deterministic-ish simulated status, used only for non-Stellar-shaped hashes (demo/dev flows). */
+function getSimulatedTxStatus(hash: string): TxStatus {
   let record = txStore.get(hash);
 
   if (!record) {
@@ -46,7 +78,9 @@ export async function GET(
     );
   }
 
-  const result = getStatusForTx(txHash);
+  const result = STELLAR_TX_HASH_PATTERN.test(txHash)
+    ? await getRealTxStatus(txHash)
+    : getSimulatedTxStatus(txHash);
 
   return NextResponse.json(result);
 }

--- a/app/components/WalletConnectionIndicator.tsx
+++ b/app/components/WalletConnectionIndicator.tsx
@@ -10,12 +10,16 @@ interface WalletConnectionIndicatorProps {
   showLabel?: boolean;
 }
 
-export default function WalletConnectionIndicator({ 
-  variant = "user", 
+function shortenAddress(address: string): string {
+  return address.length > 12 ? `${address.slice(0, 6)}…${address.slice(-4)}` : address;
+}
+
+export default function WalletConnectionIndicator({
+  variant = "user",
   className = "",
-  showLabel = true 
+  showLabel = true
 }: WalletConnectionIndicatorProps) {
-  const { walletConnected } = useUserSessionSync();
+  const { walletConnected, walletName, walletAddress } = useUserSessionSync();
 
   const baseClasses = "flex items-center gap-2 transition-all duration-200";
   const variantClasses = variant === "organizer" 
@@ -37,7 +41,11 @@ export default function WalletConnectionIndicator({
       )}
       {showLabel && (
         <span>
-          {walletConnected ? "Connected" : "Disconnected"}
+          {walletConnected
+            ? [walletName, walletAddress && shortenAddress(walletAddress)]
+                .filter(Boolean)
+                .join(" · ") || "Connected"
+            : "Disconnected"}
         </span>
       )}
     </div>

--- a/app/components/explore/EventCheckout/TicketInfo.test.tsx
+++ b/app/components/explore/EventCheckout/TicketInfo.test.tsx
@@ -7,10 +7,12 @@ import type { TicketType } from "@/lib/dummyEvents/events";
 
 const mockSignTransaction = vi.fn();
 const mockPreloadWalletSDK = vi.fn();
+const mockGetConnectedAccount = vi.fn();
 
 vi.mock("@/lib/walletSdk", () => ({
   signTransaction: (...args: unknown[]) => mockSignTransaction(...args),
   preloadWalletSDK: (...args: unknown[]) => mockPreloadWalletSDK(...args),
+  getConnectedAccount: (...args: unknown[]) => mockGetConnectedAccount(...args),
 }));
 
 const mockSetWalletConnected = vi.fn();
@@ -91,6 +93,11 @@ describe("TicketInfo (event checkout)", () => {
     sessionState = { anonymousBrowsing: false, walletConnected: false };
     availabilityState = { slotsLeft: 10, isSoldOut: false };
     mockSignTransaction.mockResolvedValue("tx_abc123");
+    mockGetConnectedAccount.mockReturnValue({
+      address: "GATESTPUBLICKEY",
+      chain: "stellar",
+      walletName: "Freighter",
+    });
   });
 
   it("renders every ticket type and defaults to the first one selected", () => {
@@ -137,7 +144,10 @@ describe("TicketInfo (event checkout)", () => {
     await user.click(screen.getByText("Confirm Trust Prompt"));
 
     await waitFor(() => expect(mockSignTransaction).toHaveBeenCalledTimes(1));
-    expect(mockSetWalletConnected).toHaveBeenCalledWith(true);
+    expect(mockSetWalletConnected).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({ walletName: "Freighter" })
+    );
     expect(mockStartTracking).toHaveBeenCalledWith("tx_abc123");
   });
 

--- a/app/components/explore/EventCheckout/TicketInfo.test.tsx
+++ b/app/components/explore/EventCheckout/TicketInfo.test.tsx
@@ -1,0 +1,167 @@
+import type { ComponentProps } from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { TicketInfo } from "./TicketInfo";
+import type { TicketType } from "@/lib/dummyEvents/events";
+
+const mockSignTransaction = vi.fn();
+const mockPreloadWalletSDK = vi.fn();
+
+vi.mock("@/lib/walletSdk", () => ({
+  signTransaction: (...args: unknown[]) => mockSignTransaction(...args),
+  preloadWalletSDK: (...args: unknown[]) => mockPreloadWalletSDK(...args),
+}));
+
+const mockSetWalletConnected = vi.fn();
+const mockSetAnonymousBrowsing = vi.fn();
+let sessionState = { anonymousBrowsing: false, walletConnected: false };
+
+vi.mock("@/lib/user-session-sync", () => ({
+  useUserSessionSync: () => ({
+    anonymousBrowsing: sessionState.anonymousBrowsing,
+    walletConnected: sessionState.walletConnected,
+    setAnonymousBrowsing: mockSetAnonymousBrowsing,
+    setWalletConnected: mockSetWalletConnected,
+  }),
+}));
+
+let availabilityState = { slotsLeft: 10, isSoldOut: false };
+vi.mock("@/lib/hooks/useSimulatedAvailability", () => ({
+  useSimulatedAvailability: () => availabilityState,
+}));
+
+vi.mock("@/hooks/useCooldown", () => ({
+  useCooldown: () => ({
+    isOnCooldown: false,
+    remainingSeconds: 0,
+    startCooldown: vi.fn(),
+  }),
+}));
+
+const mockStartTracking = vi.fn();
+vi.mock("@/hooks/useTransactionStatus", () => ({
+  useTransactionStatus: () => ({
+    status: "idle",
+    txHash: null,
+    error: null,
+    startTracking: mockStartTracking,
+    reset: vi.fn(),
+    checkConnection: vi.fn(),
+  }),
+}));
+
+// Radix Dialog isn't the focus of this test — replace with a minimal double
+// that exposes the same confirm/close contract used by TicketInfo.
+vi.mock("@/app/components/privacy/PrivacyTrustModal", () => ({
+  PrivacyTrustModal: ({
+    isOpen,
+    onConfirm,
+  }: {
+    isOpen: boolean;
+    onConfirm: () => void;
+  }) =>
+    isOpen ? (
+      <button type="button" onClick={onConfirm}>
+        Confirm Trust Prompt
+      </button>
+    ) : null,
+}));
+
+const ticketTypes: TicketType[] = [
+  { name: "General Admission", price: 20 },
+  { name: "VIP", price: 50 },
+];
+
+function renderTicketInfo(overrides: Partial<ComponentProps<typeof TicketInfo>> = {}) {
+  return render(
+    <TicketInfo
+      eventId="test-event"
+      ticketTypes={ticketTypes}
+      privacyLevel={["Wallet Required"]}
+      isPaid
+      {...overrides}
+    />
+  );
+}
+
+describe("TicketInfo (event checkout)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sessionState = { anonymousBrowsing: false, walletConnected: false };
+    availabilityState = { slotsLeft: 10, isSoldOut: false };
+    mockSignTransaction.mockResolvedValue("tx_abc123");
+  });
+
+  it("renders every ticket type and defaults to the first one selected", () => {
+    renderTicketInfo();
+    const first = screen.getByLabelText("General Admission") as HTMLInputElement;
+    const second = screen.getByLabelText("VIP") as HTMLInputElement;
+    expect(first.checked).toBe(true);
+    expect(second.checked).toBe(false);
+  });
+
+  it("increments and decrements quantity within the available slots", async () => {
+    const user = userEvent.setup();
+    availabilityState = { slotsLeft: 2, isSoldOut: false };
+    renderTicketInfo();
+
+    expect(screen.getByText("1")).toBeInTheDocument();
+
+    const decrement = screen.getByRole("button", { name: "Decrease quantity" });
+    const increment = screen.getByRole("button", { name: "Increase quantity" });
+
+    // Increment up to the slot cap, then it should not exceed it.
+    await user.click(increment);
+    expect(screen.getByText("2")).toBeInTheDocument();
+    await user.click(increment);
+    expect(screen.getByText("2")).toBeInTheDocument(); // capped at slotsLeft
+
+    await user.click(decrement);
+    expect(screen.getByText("1")).toBeInTheDocument();
+  });
+
+  it("disables the purchase button and shows sold-out messaging when there is no availability", () => {
+    availabilityState = { slotsLeft: 0, isSoldOut: true };
+    renderTicketInfo();
+
+    expect(screen.getByText("This event is sold out.")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /sold out/i })).toBeDisabled();
+  });
+
+  it("opens the privacy trust prompt, then signs a transaction and starts tracking on confirm for paid events", async () => {
+    const user = userEvent.setup();
+    renderTicketInfo({ isPaid: true });
+
+    await user.click(screen.getByRole("button", { name: /connect wallet to purchase/i }));
+    await user.click(screen.getByText("Confirm Trust Prompt"));
+
+    await waitFor(() => expect(mockSignTransaction).toHaveBeenCalledTimes(1));
+    expect(mockSetWalletConnected).toHaveBeenCalledWith(true);
+    expect(mockStartTracking).toHaveBeenCalledWith("tx_abc123");
+  });
+
+  it("enables anonymous attendance for free events without touching the wallet SDK", async () => {
+    const user = userEvent.setup();
+    const onStatusChange = vi.fn().mockResolvedValue({ ok: true });
+    renderTicketInfo({ isPaid: false, onStatusChange });
+
+    await user.click(screen.getByRole("button", { name: /attend anonymously/i }));
+    await user.click(screen.getByText("Confirm Trust Prompt"));
+
+    await waitFor(() => expect(onStatusChange).toHaveBeenCalledWith({ isConfirmed: true, isPaid: false }));
+    expect(mockSignTransaction).not.toHaveBeenCalled();
+    expect(mockSetAnonymousBrowsing).toHaveBeenCalledWith(true);
+  });
+
+  it("surfaces a wallet error banner when signing fails", async () => {
+    const user = userEvent.setup();
+    mockSignTransaction.mockRejectedValueOnce(new Error("Wallet locked"));
+    renderTicketInfo({ isPaid: true });
+
+    await user.click(screen.getByRole("button", { name: /connect wallet to purchase/i }));
+    await user.click(screen.getByText("Confirm Trust Prompt"));
+
+    expect(await screen.findByText("Wallet locked")).toBeInTheDocument();
+  });
+});

--- a/app/components/explore/EventCheckout/TicketInfo.tsx
+++ b/app/components/explore/EventCheckout/TicketInfo.tsx
@@ -380,6 +380,7 @@ export const TicketInfo: FC<TicketInfoProps> = ({
                 <button
                   disabled={clampedQuantity === 1}
                   type="button"
+                  aria-label="Decrease quantity"
                   onClick={decrementQuantity}
                   className={`${clampedQuantity === 1
                     ? "text-[#667185] cursor-not-allowed"
@@ -393,6 +394,7 @@ export const TicketInfo: FC<TicketInfoProps> = ({
                 </p>
                 <button
                   type="button"
+                  aria-label="Increase quantity"
                   onClick={incrementQuantity}
                   disabled={isSoldOut || clampedQuantity === liveSlotsLeft}
                   className={`${isSoldOut || clampedQuantity === liveSlotsLeft

--- a/app/components/explore/EventCheckout/TicketInfo.tsx
+++ b/app/components/explore/EventCheckout/TicketInfo.tsx
@@ -14,7 +14,7 @@ import {
 } from "@/public/svg/svg";
 import { TicketType, PrivacyLevel } from "@/lib/dummyEvents/events";
 import { PrivacyLevelExplanationModal } from "../PrivacyLevelInfo";
-import { signTransaction, preloadWalletSDK, WalletLoadState } from "@/lib/walletSdk";
+import { signTransaction, preloadWalletSDK, getConnectedAccount, WalletLoadState } from "@/lib/walletSdk";
 import { useUserSessionSync } from "@/lib/user-session-sync";
 import { useCooldown } from "@/hooks/useCooldown";
 import { CooldownMessage } from "@/app/components/AntiSpam/CooldownMessage";
@@ -179,7 +179,7 @@ export const TicketInfo: FC<TicketInfoProps> = ({
     try {
       if (isPaid) {
         const txHash = await signTransaction();
-        setWalletConnected(true);
+        setWalletConnected(true, getConnectedAccount() ?? undefined);
         setWalletState({ isLoading: false, error: null });
         startTracking(txHash);
       } else {
@@ -476,8 +476,8 @@ export const TicketInfo: FC<TicketInfoProps> = ({
             type="button"
             disabled={isSoldOut || isProcessingPayment || walletState.isLoading || isButtonDisabled}
             onClick={handlePrimaryClick}
-            onMouseEnter={isSoldOut ? undefined : preloadWalletSDK}
-            onFocus={isSoldOut ? undefined : preloadWalletSDK}
+            onMouseEnter={isSoldOut ? undefined : () => preloadWalletSDK()}
+            onFocus={isSoldOut ? undefined : () => preloadWalletSDK()}
             className={
               isSoldOut
                 ? "py-4 px-6 flex w-full items-center justify-center font-bold rounded-full gap-3 duration-200 ease-in-out transition bg-[#E4E5E6] text-[#98A2B3] cursor-not-allowed dark:bg-[#232323] dark:text-[#667085]"

--- a/app/components/explore/MainContent.test.tsx
+++ b/app/components/explore/MainContent.test.tsx
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import MainContent from "./MainContent";
+import type { Event } from "@/lib/dummyEvents/events";
+
+const mockReplace = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: mockReplace }),
+  usePathname: () => "/explore",
+}));
+
+vi.mock("@/lib/hooks/useSimulatedAvailability", () => ({
+  useSimulatedAvailability: () => ({ slotsLeft: 10, isSoldOut: false }),
+}));
+
+function makeEvent(overrides: Partial<Event>): Event {
+  return {
+    id: overrides.id ?? "event-id",
+    title: overrides.title ?? "Sample Event",
+    date: overrides.date ?? "Jun. 04 2025",
+    time: "4:00 pm (UTC +01:00)",
+    location: overrides.location ?? "Accra, Ghana",
+    type: overrides.type ?? "Music",
+    image: "/images/explore/1.png",
+    description: "A sample event for testing.",
+    tags: [],
+    perks: [],
+    organizer: { name: "Organizer", bio: "Bio", contact: "contact@example.com" },
+    slotsLeft: 10,
+    quantitySelected: 1,
+    isPaid: overrides.price ? overrides.price > 0 : false,
+    price: overrides.price ?? 0,
+    ticketTypes: [{ name: "General", price: overrides.price ?? 0 }],
+    privacyLevel: overrides.privacyLevel ?? ["Anonymous"],
+    ...overrides,
+  } as Event;
+}
+
+const events: Event[] = [
+  makeEvent({ id: "free-accra", title: "Free Accra Meetup", price: 0, location: "Accra, Ghana" }),
+  makeEvent({ id: "paid-lagos", title: "Paid Lagos Summit", price: 100, location: "Lagos, Nigeria" }),
+];
+
+describe("MainContent (event search & filtering)", () => {
+  beforeEach(() => {
+    mockReplace.mockClear();
+    window.history.replaceState(null, "", "/explore");
+  });
+
+  it("renders all events when no filters are applied", () => {
+    render(<MainContent initialEvents={events} />);
+
+    expect(screen.getByText("Free Accra Meetup")).toBeInTheDocument();
+    expect(screen.getByText("Paid Lagos Summit")).toBeInTheDocument();
+  });
+
+  it("filters events by price via the Pricing dropdown", async () => {
+    const user = userEvent.setup();
+    render(<MainContent initialEvents={events} />);
+
+    await user.click(screen.getByRole("button", { name: /pricing/i }));
+    await user.click(screen.getByRole("option", { name: /free events only/i }));
+
+    expect(screen.getByText("Free Accra Meetup")).toBeInTheDocument();
+    expect(screen.queryByText("Paid Lagos Summit")).not.toBeInTheDocument();
+  });
+
+  it("filters events by location via the Location dropdown", async () => {
+    const user = userEvent.setup();
+    render(<MainContent initialEvents={events} />);
+
+    await user.click(screen.getByRole("button", { name: /location/i }));
+    await user.click(screen.getByRole("option", { name: "Lagos, Nigeria" }));
+
+    expect(screen.getByText("Paid Lagos Summit")).toBeInTheDocument();
+    expect(screen.queryByText("Free Accra Meetup")).not.toBeInTheDocument();
+  });
+
+  it("shows the empty state and no results when filters exclude everything", async () => {
+    const user = userEvent.setup();
+    render(<MainContent initialEvents={events} />);
+
+    await user.click(screen.getByRole("button", { name: /location/i }));
+    await user.click(screen.getByRole("option", { name: "Lagos, Nigeria" }));
+    await user.click(screen.getByRole("button", { name: /pricing/i }));
+    await user.click(screen.getByRole("option", { name: /free events only/i }));
+
+    expect(screen.getByText("No events found")).toBeInTheDocument();
+  });
+
+  it("respects filters supplied via the initial query (e.g. deep link / SSR)", () => {
+    render(
+      <MainContent
+        initialEvents={events}
+        initialQuery={{
+          privacy: null,
+          price: "Paid Events Only",
+          location: null,
+          date: null,
+          eventType: null,
+          sort: null,
+        }}
+      />
+    );
+
+    expect(screen.getByText("Paid Lagos Summit")).toBeInTheDocument();
+    expect(screen.queryByText("Free Accra Meetup")).not.toBeInTheDocument();
+  });
+});

--- a/app/components/organizer/ConnectWalletPrompt.tsx
+++ b/app/components/organizer/ConnectWalletPrompt.tsx
@@ -5,9 +5,15 @@ import { ChevronRight, Loader2 } from "lucide-react";
 import { useState } from "react";
 import { trackAnalyticsEvent } from "@/lib/privacyAnalytics";
 import { loadWalletSDK, preloadWalletSDK, WalletLoadState } from "@/lib/walletSdk";
+import type { WalletChain } from "@/lib/wallet/types";
 import { useUserSessionSync } from "@/lib/user-session-sync";
 import { TransactionStatusBanner } from "@/components/TransactionStatusBanner";
 import { PrivacyTrustModal } from "@/app/components/privacy/PrivacyTrustModal";
+
+const CHAIN_OPTIONS: { id: WalletChain; label: string }[] = [
+  { id: "stellar", label: "Stellar" },
+  { id: "aztec", label: "Aztec" },
+];
 
 /**
  * Organizer-facing prompt to connect a wallet for receiving payments. Surfaces
@@ -24,7 +30,8 @@ export default function ConnectWalletPrompt() {
   // Privacy Trust prompt: the button opens this first; the wallet only connects
   // once the user confirms in the modal.
   const [trustOpen, setTrustOpen] = useState(false);
-  const { walletConnected, setWalletConnected } = useUserSessionSync();
+  const [chain, setChain] = useState<WalletChain>("stellar");
+  const { walletConnected, walletAddress, walletName, setWalletConnected } = useUserSessionSync();
 
   /** Guard, then open the trust prompt instead of connecting straight away. */
   function handleConnectWallet() {
@@ -38,9 +45,9 @@ export default function ConnectWalletPrompt() {
     setTrustOpen(false);
     setWalletState({ isLoading: true, error: null });
     try {
-      await loadWalletSDK();
-      setWalletConnected(true);
-      // TODO: invoke wallet connection flow with the loaded SDK
+      const adapter = await loadWalletSDK(chain);
+      const account = adapter.getAccount();
+      setWalletConnected(true, account ?? undefined);
       setWalletState({ isLoading: false, error: null });
     } catch (err) {
       const message =
@@ -70,10 +77,33 @@ export default function ConnectWalletPrompt() {
           Connect your wallet to receive payments from paid events.
         </p>
 
+        {!walletConnected && (
+          <div className="flex gap-2" role="radiogroup" aria-label="Wallet network">
+            {CHAIN_OPTIONS.map((option) => (
+              <button
+                key={option.id}
+                type="button"
+                role="radio"
+                aria-checked={chain === option.id}
+                onClick={() => setChain(option.id)}
+                disabled={walletState.isLoading}
+                className={`px-4 py-1.5 rounded-full text-sm font-medium border transition disabled:opacity-60 disabled:cursor-not-allowed ${
+                  chain === option.id
+                    ? "bg-[#6917AF] text-white border-[#6917AF]"
+                    : "bg-white text-[#475467] border-[#E3E3E3] hover:border-[#6917AF]"
+                }`}
+              >
+                {option.label}
+              </button>
+            ))}
+          </div>
+        )}
+
         <div className="mt-2">
           <button
             onClick={handleConnectWallet}
-            onMouseEnter={preloadWalletSDK}
+            onMouseEnter={() => preloadWalletSDK(chain)}
+            onFocus={() => preloadWalletSDK(chain)}
             disabled={walletState.isLoading}
             className="inline-flex group items-center cursor-pointer gap-2 bg-[#6917AF] hover:bg-[#5A1296] text-white font-medium text-sm md:text-base px-8 py-3 rounded-full transition whitespace-nowrap disabled:opacity-60 disabled:cursor-not-allowed"
           >
@@ -84,11 +114,16 @@ export default function ConnectWalletPrompt() {
               </>
             ) : (
               <>
-                {walletConnected ? "Wallet Connected" : "Connect Wallet"}
+                {walletConnected
+                  ? `Connected${walletName ? ` — ${walletName}` : ""}`
+                  : "Connect Wallet"}
                 <ChevronRight className="w-5 h-5 group-hover:translate-x-1 transition ease-in-out duration-300" />
               </>
             )}
           </button>
+          {walletConnected && walletAddress && (
+            <p className="mt-2 text-xs text-[#667185] break-all">{walletAddress}</p>
+          )}
           {/* Rendered unconditionally (idle collapses to nothing) so the
               banner's live region is already observed when the first error
               appears — mounting it only on error would risk a missed

--- a/e2e/ticket-purchase.spec.ts
+++ b/e2e/ticket-purchase.spec.ts
@@ -1,0 +1,81 @@
+import { test, expect, type Page } from "@playwright/test";
+
+const PAID_EVENT_PATH = "/explore/solana-summer-hackathon";
+
+/**
+ * Stubs a Freighter-compatible injected wallet provider before the app loads,
+ * so the Stellar wallet adapter (via stellar-wallets-kit) can complete a full
+ * connect + sign round trip without a real browser extension installed.
+ *
+ * NOTE: mirrors Freighter's public injected API shape. Verify method/global
+ * names against the installed `@stellar/freighter-api` / wallets-kit version
+ * if this test starts failing against a real dependency upgrade.
+ */
+async function stubFreighterWallet(page: Page) {
+  await page.addInitScript(() => {
+    (window as unknown as { freighterApi: Record<string, unknown> }).freighterApi = {
+      isConnected: async () => ({ isConnected: true }),
+      isAllowed: async () => ({ isAllowed: true }),
+      setAllowed: async () => ({ isAllowed: true }),
+      requestAccess: async () => ({ address: "GATESTPUBLICKEYFORE2ETESTINGXXXXXXXXXXXXXXXXXXXXXXXXXX" }),
+      getAddress: async () => ({ address: "GATESTPUBLICKEYFORE2ETESTINGXXXXXXXXXXXXXXXXXXXXXXXXXX" }),
+      getNetwork: async () => ({ network: "TESTNET", networkPassphrase: "Test SDF Network ; September 2015" }),
+      signTransaction: async () => ({ signedTxXdr: "AAAAAgAAAABE2ETESTSIGNEDXDR", signerAddress: "GATESTPUBLICKEYFORE2ETESTINGXXXXXXXXXXXXXXXXXXXXXXXXXX" }),
+    };
+  });
+}
+
+test.describe("Ticket purchase flow", () => {
+  test("lets a user pick a ticket, quantity, and reach the wallet connection step", async ({ page }) => {
+    await page.goto(PAID_EVENT_PATH);
+
+    await expect(page.getByRole("heading", { name: "Ticket Info" })).toBeVisible();
+
+    // Ticket type selection defaults to the first option; switch to a
+    // different one to prove the radio group is interactive.
+    const vipOption = page.getByLabel("VIP", { exact: true });
+    await vipOption.check();
+    await expect(vipOption).toBeChecked();
+
+    // Bump quantity by one.
+    await page.getByRole("button", { name: "Increase quantity" }).click();
+    await expect(page.getByText("2", { exact: true })).toBeVisible();
+
+    // Kick off purchase -> Privacy Trust prompt appears first.
+    await page.getByRole("button", { name: /connect wallet to purchase/i }).click();
+    await expect(page.getByRole("dialog")).toBeVisible();
+    await page.getByRole("button", { name: /allow|confirm/i }).click();
+
+    // Wallet selection modal should offer the documented set of wallets.
+    const walletModal = page.getByRole("dialog").last();
+    await expect(walletModal).toBeVisible();
+    await expect(walletModal.getByText(/freighter/i)).toBeVisible();
+    await expect(walletModal.getByText(/lobstr/i)).toBeVisible();
+    await expect(walletModal.getByText(/wallet ?connect/i)).toBeVisible();
+  });
+
+  test("completes a full purchase against a stubbed Freighter wallet", async ({ page }) => {
+    await stubFreighterWallet(page);
+
+    // Mock the on-chain status polling endpoint so the test doesn't depend on
+    // real chain confirmation timing.
+    await page.route("**/api/transactions/*/status", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ status: "confirmed" }),
+      });
+    });
+
+    await page.goto(PAID_EVENT_PATH);
+
+    await page.getByRole("button", { name: /connect wallet to purchase/i }).click();
+    await page.getByRole("dialog").getByRole("button", { name: /allow|confirm/i }).click();
+
+    await page.getByRole("dialog").last().getByText(/freighter/i).click();
+
+    await expect(page.getByRole("button", { name: /ticket confirmed/i })).toBeVisible({
+      timeout: 15_000,
+    });
+  });
+});

--- a/lib/user-session-sync.ts
+++ b/lib/user-session-sync.ts
@@ -1,10 +1,14 @@
 'use client';
 
 import { useSyncExternalStore } from 'react';
+import type { WalletAccount, WalletChain } from './wallet/types';
 
 type SessionState = {
   anonymousBrowsing: boolean;
   walletConnected: boolean;
+  walletAddress: string | null;
+  walletName: string | null;
+  walletChain: WalletChain | null;
 };
 
 type SessionStateUpdate = Partial<SessionState>;
@@ -16,6 +20,9 @@ const CHANNEL_NAME = 'zicket-user-session';
 let state: SessionState = {
   anonymousBrowsing: false,
   walletConnected: false,
+  walletAddress: null,
+  walletName: null,
+  walletChain: null,
 };
 
 let initialized = false;
@@ -36,6 +43,9 @@ const parseState = (value: string | null): SessionState | null => {
     return {
       anonymousBrowsing: Boolean(parsed.anonymousBrowsing),
       walletConnected: Boolean(parsed.walletConnected),
+      walletAddress: parsed.walletAddress ?? null,
+      walletName: parsed.walletName ?? null,
+      walletChain: parsed.walletChain ?? null,
     };
   } catch {
     return null;
@@ -125,7 +135,12 @@ export const useUserSessionSync = () => {
     ...snapshot,
     setAnonymousBrowsing: (anonymousBrowsing: boolean) =>
       updateUserSessionState({ anonymousBrowsing }),
-    setWalletConnected: (walletConnected: boolean) =>
-      updateUserSessionState({ walletConnected }),
+    setWalletConnected: (walletConnected: boolean, account?: WalletAccount) =>
+      updateUserSessionState({
+        walletConnected,
+        walletAddress: walletConnected ? (account?.address ?? null) : null,
+        walletName: walletConnected ? (account?.walletName ?? null) : null,
+        walletChain: walletConnected ? (account?.chain ?? null) : null,
+      }),
   };
 };

--- a/lib/wallet/aztecAdapter.ts
+++ b/lib/wallet/aztecAdapter.ts
@@ -1,0 +1,80 @@
+/**
+ * Aztec wallet adapter — targets the Azguard Wallet browser extension (the
+ * closest thing to a "Aztec Passport" today), which injects a `window.azguard`
+ * provider following the same request({ method, params }) shape most injected
+ * wallets use.
+ *
+ * CAUTION: Aztec's wallet-connection standard is still young and Azguard's
+ * exact RPC method names may drift between versions. `connect()` / account
+ * discovery below follow the documented `window.azguard.connect()` +
+ * `.request()` pattern; verify the method names against the installed
+ * `@aztec/aztec.js` / Azguard docs before relying on this in production —
+ * the same caveat the previous mock implementation carried for this chain.
+ */
+import { AztecAddress } from "@aztec/aztec.js";
+import type { SignedTransactionResult, WalletAccount, WalletAdapter } from "./types";
+import { WalletNotInstalledError } from "./types";
+
+interface AzguardProvider {
+  connect: (chainId?: string) => Promise<{ address: string }>;
+  disconnect?: () => Promise<void>;
+  request: <T = unknown>(args: { method: string; params?: unknown[] }) => Promise<T>;
+}
+
+function getAzguardProvider(): AzguardProvider | null {
+  if (typeof window === "undefined") return null;
+  return (window as unknown as { azguard?: AzguardProvider }).azguard ?? null;
+}
+
+class AztecWalletAdapter implements WalletAdapter {
+  readonly chain = "aztec" as const;
+  private account: WalletAccount | null = null;
+
+  isConnected(): boolean {
+    return this.account !== null;
+  }
+
+  getAccount(): WalletAccount | null {
+    return this.account;
+  }
+
+  async connect(): Promise<WalletAccount> {
+    const provider = getAzguardProvider();
+    if (!provider) {
+      throw new WalletNotInstalledError("Azguard (Aztec)");
+    }
+
+    const { address } = await provider.connect();
+    // Validates the address is a well-formed Aztec address before trusting it.
+    AztecAddress.fromString(address);
+
+    this.account = { address, chain: "aztec", walletName: "Azguard" };
+    return this.account;
+  }
+
+  async disconnect(): Promise<void> {
+    const provider = getAzguardProvider();
+    await provider?.disconnect?.();
+    this.account = null;
+  }
+
+  async signTransaction(payload?: string): Promise<SignedTransactionResult> {
+    const provider = getAzguardProvider();
+    if (!provider || !this.account) {
+      throw new Error("Connect an Aztec wallet before signing a transaction.");
+    }
+
+    // TODO: replace with the real Aztec PXE transaction-execution request once
+    // the ticket-purchase contract call is defined (destination contract,
+    // function selector, and args). `send_transaction` mirrors Azguard's
+    // documented request method name at the time of writing.
+    const result = await provider.request<{ txHash: string }>({
+      method: "send_transaction",
+      params: [payload ?? { memo: "zicket-ticket" }],
+    });
+
+    return { txHash: result.txHash, signedPayload: payload ?? "" };
+  }
+}
+
+export const aztecWalletAdapter: WalletAdapter = new AztecWalletAdapter();

--- a/lib/wallet/stellarAdapter.ts
+++ b/lib/wallet/stellarAdapter.ts
@@ -1,0 +1,171 @@
+/**
+ * Stellar wallet adapter — connects real browser wallets (Freighter, Lobstr,
+ * WalletConnect, xBull, Albedo, Rabet, Hana) through `@creit.tech/stellar-wallets-kit`,
+ * which owns wallet discovery/selection and delegates signing to whichever
+ * wallet the user picks. This replaces the old `mock_tx_...` random string
+ * generator with a real signed transaction submitted to Horizon.
+ *
+ * NOTE: There is no organizer payout address in the data model yet, so the
+ * default (no-argument) `signTransaction()` call signs a minimal self-payment
+ * (1 stroop, memo "zicket-ticket") purely to produce a real, verifiable
+ * on-chain transaction for the checkout flow. Once ticket purchases have a
+ * real destination (organizer wallet + priced asset), build that XDR
+ * server-side and pass it into `signTransaction(xdr)` instead.
+ */
+import {
+  StellarWalletsKit,
+  WalletNetwork,
+  FreighterModule,
+  LobstrModule,
+  xBullModule,
+  WalletConnectModule,
+  WalletConnectAllowedMethods,
+  FREIGHTER_ID,
+  type ISupportedWallet,
+} from "@creit.tech/stellar-wallets-kit";
+import {
+  TransactionBuilder,
+  Networks,
+  Operation,
+  Asset,
+  Memo,
+  BASE_FEE,
+  Horizon,
+} from "@stellar/stellar-sdk";
+import type { SignedTransactionResult, WalletAccount, WalletAdapter } from "./types";
+import { WalletNotInstalledError } from "./types";
+
+const NETWORK = (process.env.NEXT_PUBLIC_STELLAR_NETWORK ?? "testnet") as "testnet" | "public";
+const NETWORK_PASSPHRASE = NETWORK === "public" ? Networks.PUBLIC : Networks.TESTNET;
+const HORIZON_URL =
+  process.env.NEXT_PUBLIC_STELLAR_HORIZON_URL ??
+  (NETWORK === "public" ? "https://horizon.stellar.org" : "https://horizon-testnet.stellar.org");
+const WALLET_CONNECT_PROJECT_ID = process.env.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID;
+
+function buildModules() {
+  const modules = [new FreighterModule(), new LobstrModule(), new xBullModule()];
+
+  // WalletConnect requires a Cloud project id (https://cloud.walletconnect.com) —
+  // only register it once one is configured so local/dev setups without it
+  // still get Freighter/Lobstr/xBull.
+  if (WALLET_CONNECT_PROJECT_ID) {
+    modules.push(
+      new WalletConnectModule({
+        url: typeof window !== "undefined" ? window.location.origin : "https://zicket.app",
+        projectId: WALLET_CONNECT_PROJECT_ID,
+        method: WalletConnectAllowedMethods.SIGN,
+        description: "Zicket — private, on-chain event ticketing",
+        name: "Zicket",
+        icons: ["https://zicket.app/favicon.ico"],
+        network: NETWORK === "public" ? WalletNetwork.PUBLIC : WalletNetwork.TESTNET,
+      })
+    );
+  }
+
+  return modules;
+}
+
+let kit: StellarWalletsKit | null = null;
+function getKit(): StellarWalletsKit {
+  if (!kit) {
+    kit = new StellarWalletsKit({
+      network: NETWORK === "public" ? WalletNetwork.PUBLIC : WalletNetwork.TESTNET,
+      selectedWalletId: FREIGHTER_ID,
+      modules: buildModules(),
+    });
+  }
+  return kit;
+}
+
+function getHorizonServer(): Horizon.Server {
+  return new Horizon.Server(HORIZON_URL);
+}
+
+/** Opens the kit's wallet picker (Freighter / Lobstr / WalletConnect / xBull) and resolves once the user selects one. */
+function selectWallet(): Promise<ISupportedWallet> {
+  return new Promise((resolve, reject) => {
+    getKit()
+      .openModal({
+        modalTitle: "Connect a Stellar wallet",
+        notAvailableText: "Wallet not installed",
+        onWalletSelected: (option) => resolve(option),
+        onClosed: (err) => {
+          if (err) reject(err);
+        },
+      })
+      .catch(reject);
+  });
+}
+
+class StellarWalletAdapter implements WalletAdapter {
+  readonly chain = "stellar" as const;
+  private account: WalletAccount | null = null;
+
+  isConnected(): boolean {
+    return this.account !== null;
+  }
+
+  getAccount(): WalletAccount | null {
+    return this.account;
+  }
+
+  async connect(): Promise<WalletAccount> {
+    const selected = await selectWallet();
+    getKit().setWallet(selected.id);
+
+    const { address } = await getKit().getAddress();
+    if (!address) {
+      throw new WalletNotInstalledError(selected.name);
+    }
+
+    this.account = { address, chain: "stellar", walletName: selected.name };
+    return this.account;
+  }
+
+  async disconnect(): Promise<void> {
+    await getKit().disconnect();
+    this.account = null;
+  }
+
+  async signTransaction(payload?: string): Promise<SignedTransactionResult> {
+    if (!this.account) {
+      throw new Error("Connect a Stellar wallet before signing a transaction.");
+    }
+
+    const server = getHorizonServer();
+    const xdr = payload ?? (await this.buildDemoTicketTransaction(server, this.account.address));
+
+    const { signedTxXdr } = await getKit().signTransaction(xdr, {
+      address: this.account.address,
+      networkPassphrase: NETWORK_PASSPHRASE,
+    });
+
+    const signedTx = TransactionBuilder.fromXDR(signedTxXdr, NETWORK_PASSPHRASE);
+    const response = await server.submitTransaction(signedTx);
+
+    return { txHash: response.hash, signedPayload: signedTxXdr };
+  }
+
+  /** Minimal, real, cheap-to-submit transaction used until ticket purchases have a priced destination wired in. */
+  private async buildDemoTicketTransaction(server: Horizon.Server, address: string): Promise<string> {
+    const account = await server.loadAccount(address);
+    const transaction = new TransactionBuilder(account, {
+      fee: BASE_FEE,
+      networkPassphrase: NETWORK_PASSPHRASE,
+    })
+      .addOperation(
+        Operation.payment({
+          destination: address,
+          asset: Asset.native(),
+          amount: "0.0000001",
+        })
+      )
+      .addMemo(Memo.text("zicket-ticket"))
+      .setTimeout(180)
+      .build();
+
+    return transaction.toXDR();
+  }
+}
+
+export const stellarWalletAdapter: WalletAdapter = new StellarWalletAdapter();

--- a/lib/wallet/types.ts
+++ b/lib/wallet/types.ts
@@ -1,0 +1,45 @@
+/**
+ * Shared contract every chain-specific wallet adapter implements. Keeping this
+ * chain-agnostic lets `lib/walletSdk.ts` route connect/sign calls to whichever
+ * network (Stellar today, Aztec next) without the UI layer knowing the
+ * difference.
+ */
+
+export type WalletChain = "stellar" | "aztec";
+
+export interface WalletAccount {
+  address: string;
+  chain: WalletChain;
+  /** Human-readable wallet name, e.g. "Freighter", "Lobstr", "Azguard". */
+  walletName: string;
+}
+
+export interface SignedTransactionResult {
+  /** Network transaction hash — usable for on-chain lookups/explorers. */
+  txHash: string;
+  /** Raw signed payload (signed XDR for Stellar, tx object for Aztec). */
+  signedPayload: string;
+}
+
+export interface WalletAdapter {
+  readonly chain: WalletChain;
+  /** Opens the wallet's connection UI (or the multi-wallet picker) and returns the connected account. */
+  connect(): Promise<WalletAccount>;
+  disconnect(): Promise<void>;
+  isConnected(): boolean;
+  getAccount(): WalletAccount | null;
+  /**
+   * Signs (and submits, where the chain requires it) a transaction and
+   * returns the resulting on-chain hash. `payload` is chain-specific
+   * (e.g. an unsigned XDR for Stellar); omit it to sign the adapter's
+   * built-in demo transaction.
+   */
+  signTransaction(payload?: string): Promise<SignedTransactionResult>;
+}
+
+export class WalletNotInstalledError extends Error {
+  constructor(walletName: string) {
+    super(`${walletName} is not installed or not detected in this browser.`);
+    this.name = "WalletNotInstalledError";
+  }
+}

--- a/lib/walletSdk.ts
+++ b/lib/walletSdk.ts
@@ -1,73 +1,62 @@
 /**
- * Lazy loader for the Wallet SDK.
+ * Facade over the chain-specific wallet adapters in `lib/wallet/`.
  *
- * This module is the single source of truth for all dynamic import logic.
- * Both TicketInfo and ConnectWalletPrompt import from here.
+ * This module is the single source of truth for wallet loading/connect/sign
+ * logic used by both `TicketInfo` (attendee checkout) and `ConnectWalletPrompt`
+ * (organizer payout setup).
  *
- * **Architecture**: SDK module loading is cached (loaded once per session),
- * but transaction signing is always executed fresh so every payment attempt
- * receives a unique transaction hash. Retries, subsequent purchases, and
- * concurrent wallet connections never reuse a stale signature.
- *
- * NOTE: Replace "wallet-sdk-package" below with the actual Azguard/wallet SDK
- * package name once it is added to package.json (e.g. "@azguard/sdk" or similar).
+ * **Architecture**: adapter modules are lazy-loaded (dynamic import, cached
+ * once per session) so `stellar-wallets-kit` / `@aztec/aztec.js` never end up
+ * in the initial bundle. Connecting always goes through the real wallet's
+ * in-extension UI — there is no more mock signature generation.
  */
+import type { WalletAdapter, WalletChain, WalletAccount, SignedTransactionResult } from "./wallet/types";
 
-// The shape of the wallet SDK once loaded
-export interface WalletSDK {
-  connect: () => Promise<{ address: string }>;
-  disconnect: () => Promise<void>;
-  isConnected: () => boolean;
-  // TODO: add signAndSendTransaction once the real SDK is wired
-  // signAndSendTransaction: (params: unknown) => Promise<{ txHash: string }>;
-}
+export type WalletSDK = WalletAdapter;
 
-/**
- * Ephemeral UI state for components that trigger wallet loading.
- * Intended for use as local component state.
- */
+/** Ephemeral UI state for components that trigger wallet loading. */
 export type WalletLoadState = {
-  isLoading: boolean;   // true while the dynamic import is in-flight
-  error: string | null; // non-null when the import failed
+  isLoading: boolean; // true while connecting/loading is in-flight
+  error: string | null; // non-null when the connect/load failed
 };
 
+const DEFAULT_CHAIN: WalletChain = "stellar";
+
 //──────────────────────────────────────────────────────────────────────────────
-// Internal: SDK module loading cache
+// Internal: adapter module loading cache (one promise per chain)
 //──────────────────────────────────────────────────────────────────────────────
 
-/** Cached SDK instance — loaded once per session, shared across all callers. */
-let sdkLoadPromise: Promise<WalletSDK> | null = null;
+const adapterLoadPromises = new Map<WalletChain, Promise<WalletAdapter>>();
+// Populated once a chain's adapter module has resolved, so already-loaded
+// adapters can be read synchronously (see getConnectedAccount below).
+const resolvedAdapters = new Map<WalletChain, WalletAdapter>();
 
-/**
- * Dynamically imports (or returns the cached) wallet SDK module.
- * Safe to call concurrently — in-flight requests share the same promise.
- */
-async function getOrLoadSDK(): Promise<WalletSDK> {
-  if (!sdkLoadPromise) {
-    const current = new Promise<WalletSDK>((resolve) =>
-      setTimeout(
-        () =>
-          resolve({
-            connect: async () => ({
-              address: "0x" + Math.random().toString(36).slice(2, 10),
-            }),
-            disconnect: async () => {},
-            isConnected: () => true,
-          }),
-        1500
-      )
-    );
-    sdkLoadPromise = current;
-
-    // Clear on failure only so a failed load can be retried.
-    // On success the SDK stays cached — subsequent signTransaction() calls
-    // reuse it without reloading.
-    const clearIfCurrent = () => {
-      if (sdkLoadPromise === current) sdkLoadPromise = null;
-    };
-    void current.then(undefined, clearIfCurrent);
+async function importAdapter(chain: WalletChain): Promise<WalletAdapter> {
+  if (chain === "aztec") {
+    const { aztecWalletAdapter } = await import("./wallet/aztecAdapter");
+    return aztecWalletAdapter;
   }
-  return sdkLoadPromise;
+  const { stellarWalletAdapter } = await import("./wallet/stellarAdapter");
+  return stellarWalletAdapter;
+}
+
+/** Dynamically imports (or returns the cached) adapter for a chain. Safe to call concurrently. */
+function getOrLoadAdapter(chain: WalletChain): Promise<WalletAdapter> {
+  const cached = adapterLoadPromises.get(chain);
+  if (cached) return cached;
+
+  const current = importAdapter(chain).then((adapter) => {
+    resolvedAdapters.set(chain, adapter);
+    return adapter;
+  });
+  adapterLoadPromises.set(chain, current);
+
+  // Clear on failure only so a failed load can be retried.
+  current.catch(() => {
+    if (adapterLoadPromises.get(chain) === current) adapterLoadPromises.delete(chain);
+  });
+
+  return current;
 }
 
 //──────────────────────────────────────────────────────────────────────────────
@@ -75,60 +64,43 @@ async function getOrLoadSDK(): Promise<WalletSDK> {
 //──────────────────────────────────────────────────────────────────────────────
 
 /**
- * Loads and connects the wallet SDK. The SDK module is only loaded once;
- * subsequent calls reuse the cached instance.
- *
- * Returns the connected SDK instance for callers that need the wallet address
- * or need to call other SDK methods.
+ * Loads the adapter for `chain` and, if not already connected, opens the
+ * wallet connection UI (for Stellar this is the Freighter / Lobstr /
+ * WalletConnect / xBull picker). Returns the connected adapter.
  */
-export async function loadWalletSDK(): Promise<WalletSDK> {
-  const sdk = await getOrLoadSDK();
-  await sdk.connect();
-  return sdk;
+export async function loadWalletSDK(chain: WalletChain = DEFAULT_CHAIN): Promise<WalletAdapter> {
+  const adapter = await getOrLoadAdapter(chain);
+  if (!adapter.isConnected()) {
+    await adapter.connect();
+  }
+  return adapter;
+}
+
+/** Returns the currently connected account for `chain`, if its adapter has already been loaded and connected. */
+export function getConnectedAccount(chain: WalletChain = DEFAULT_CHAIN): WalletAccount | null {
+  return resolvedAdapters.get(chain)?.getAccount() ?? null;
 }
 
 /**
- * Signs a new transaction and returns a unique transaction hash.
- *
- * Unlike the cached SDK module, this ALWAYS executes fresh — every call
- * generates a new cryptographic signature. Safe for retries, subsequent
- * purchases, and concurrent payments — no hash is ever reused.
- *
- * Returns: txHash string — used by the transaction lifecycle tracker in TicketInfo.
+ * Connects (if needed) and signs a transaction on `chain`, returning the real
+ * on-chain transaction hash. Every call executes a fresh sign — safe for
+ * retries, subsequent purchases, and concurrent payments.
  */
-export async function signTransaction(): Promise<string> {
-  await loadWalletSDK(); // ensure SDK is loaded AND wallet is connected
-
-  // ── MOCK (development only) ───────────────────────────────────────────────
-  // Simulates ~500 ms signing latency and returns a fresh fake Solana-style
-  // transaction hash every call. Remove this block when the real SDK is wired.
-  return new Promise<string>((resolve) =>
-    setTimeout(
-      () => resolve("mock_tx_" + Math.random().toString(36).slice(2, 18)),
-      500
-    )
-  );
-  // ── END MOCK ──────────────────────────────────────────────────────────────
-
-  // TODO: Replace the mock above with the real implementation once the Azguard
-  // SDK package is added to package.json. The wired version should look like:
-  //
-  //   const sdk = await getOrLoadSDK();
-  //   const { txHash } = await sdk.signAndSendTransaction({ ... });
-  //   return txHash;
+export async function signTransaction(chain: WalletChain = DEFAULT_CHAIN): Promise<string> {
+  const adapter = await loadWalletSDK(chain);
+  const result: SignedTransactionResult = await adapter.signTransaction();
+  return result.txHash;
 }
 
 /**
- * Kicks off the SDK import without awaiting — safe to call on hover/focus.
- * Errors are intentionally swallowed here; they will surface on the next
- * loadWalletSDK() or signTransaction() call. On failure the singleton is
- * reset so a retry is possible.
+ * Kicks off the adapter module import without awaiting — safe to call on
+ * hover/focus so the wallet-kit chunk is warm before the user clicks connect.
+ * Errors are swallowed here; they resurface on the next loadWalletSDK() /
+ * signTransaction() call. On failure the cache entry is reset so a retry works.
  */
-export function preloadWalletSDK(): void {
-  const current = getOrLoadSDK();
+export function preloadWalletSDK(chain: WalletChain = DEFAULT_CHAIN): void {
+  const current = getOrLoadAdapter(chain);
   current.catch(() => {
-    // Guard by identity so a concurrent load started after this failure
-    // isn't clobbered.
-    if (sdkLoadPromise === current) sdkLoadPromise = null;
+    if (adapterLoadPromises.get(chain) === current) adapterLoadPromises.delete(chain);
   });
 }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "test:e2e": "playwright test"
   },
   "dependencies": {
+    "@aztec/aztec.js": "^0.72.0",
+    "@creit.tech/stellar-wallets-kit": "^1.7.5",
     "@heroicons/react": "^2.2.0",
     "@hookform/resolvers": "^5.2.2",
     "@icons-pack/react-simple-icons": "^13.11.1",
@@ -25,6 +27,7 @@
     "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-switch": "^1.2.5",
     "@radix-ui/react-tooltip": "^1.2.8",
+    "@stellar/stellar-sdk": "^13.1.0",
     "@tiptap/extension-link": "^3.20.1",
     "@tiptap/extension-placeholder": "^3.20.1",
     "@tiptap/extension-text-align": "^3.20.1",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,11 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@heroicons/react": "^2.2.0",
@@ -42,14 +46,22 @@
     "zod": "^4.1.12"
   },
   "devDependencies": {
+    "@playwright/test": "^1.49.1",
     "@tailwindcss/postcss": "^4.3.3",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.1.0",
+    "@testing-library/user-event": "^14.5.2",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@vitejs/plugin-react": "^4.3.4",
+    "@vitest/coverage-v8": "^2.1.8",
     "eslint": "^9.39.3",
     "eslint-config-next": "15.3.8",
+    "jsdom": "^25.0.1",
     "tailwindcss": "^4",
     "tw-animate-css": "^1.3.3",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^2.1.8"
   }
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,30 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const PORT = process.env.E2E_PORT ?? "3100";
+const baseURL = `http://localhost:${PORT}`;
+
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: process.env.CI ? "github" : "html",
+  use: {
+    baseURL,
+    trace: "on-first-retry",
+    screenshot: "only-on-failure",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  webServer: {
+    command: `npm run build && npm run start -- -p ${PORT}`,
+    url: baseURL,
+    reuseExistingServer: !process.env.CI,
+    timeout: 180_000,
+  },
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,30 @@
+import path from "path";
+import { defineConfig } from "vitest/config";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: "jsdom",
+    globals: true,
+    setupFiles: ["./vitest.setup.ts"],
+    css: true,
+    include: ["**/*.test.{ts,tsx}"],
+    exclude: ["node_modules", ".next", "e2e"],
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "html", "lcov"],
+      include: [
+        "app/components/explore/**/*.{ts,tsx}",
+        "lib/**/*.{ts,tsx}",
+        "hooks/**/*.{ts,tsx}",
+      ],
+      exclude: ["**/*.test.{ts,tsx}", "**/*.d.ts"],
+    },
+  },
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "."),
+    },
+  },
+});

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,47 @@
+import "@testing-library/jest-dom/vitest";
+import { afterEach, vi } from "vitest";
+import { cleanup } from "@testing-library/react";
+
+afterEach(() => {
+  cleanup();
+});
+
+// jsdom does not implement matchMedia — used by next-themes / Radix.
+if (typeof window !== "undefined" && !window.matchMedia) {
+  window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }));
+}
+
+// jsdom does not implement IntersectionObserver — used for "load more" scroll.
+class MockIntersectionObserver implements IntersectionObserver {
+  readonly root: Element | Document | null = null;
+  readonly rootMargin: string = "";
+  readonly thresholds: ReadonlyArray<number> = [];
+  disconnect = vi.fn();
+  observe = vi.fn();
+  takeRecords = vi.fn(() => []);
+  unobserve = vi.fn();
+}
+vi.stubGlobal("IntersectionObserver", MockIntersectionObserver);
+
+// jsdom does not implement ResizeObserver — used by some Radix primitives.
+class MockResizeObserver {
+  observe = vi.fn();
+  unobserve = vi.fn();
+  disconnect = vi.fn();
+}
+vi.stubGlobal("ResizeObserver", MockResizeObserver);
+
+// jsdom lacks scrollIntoView / scrollTo — invoked by dropdown & filter UI.
+if (typeof window !== "undefined") {
+  window.HTMLElement.prototype.scrollIntoView = vi.fn();
+  window.scrollTo = vi.fn() as unknown as typeof window.scrollTo;
+}


### PR DESCRIPTION
## Summary

**Testing infrastructure**
- Added Vitest + React Testing Library, with `npm run test`, `test:watch`, and `test:coverage` scripts.
- Unit tests for the checkout flow (`TicketInfo.test.tsx`: ticket selection, quantity stepper, sold-out state, wallet-connect purchase flow, anonymous free-event flow, wallet error banner) and the search/filter flow (`MainContent.test.tsx`: price/location filtering, empty state, deep-link initial query).
- Added `aria-label`s to the previously unlabeled quantity stepper buttons (accessibility gap + needed for reliable test queries).
- Added Playwright for E2E, with `npm run test:e2e`. `e2e/ticket-purchase.spec.ts` covers ticket/quantity selection through the wallet connection modal, plus a full purchase run against a stubbed Freighter provider.
- Added `.github/workflows/ci.yml`: lint, type-check, unit tests (with coverage upload), and Playwright E2E on every PR to `main`.

**Native Stellar & Aztec wallet integration**
- Replaced the `mock_tx_...` random-string wallet SDK in `lib/walletSdk.ts` with a chain-agnostic facade backed by real adapters in `lib/wallet/`.
- `lib/wallet/stellarAdapter.ts`: connects Freighter, Lobstr, WalletConnect, and xBull via `@creit.tech/stellar-wallets-kit`; signs and submits real transactions to Horizon; returns genuine on-chain tx hashes.
- `lib/wallet/aztecAdapter.ts`: Azguard-compatible injected-provider adapter for Aztec, scaffolded against `@aztec/aztec.js` — flagged in comments since Aztec's wallet-connection RPC surface is still evolving.
- `app/api/transactions/[txHash]/status/route.ts` now looks up real Stellar transaction hashes on Horizon, falling back to the existing simulated status only for non-Stellar-shaped (demo/free-flow) hashes.
- `ConnectWalletPrompt.tsx` gets a Stellar/Aztec chain selector and shows the connected wallet's name/address; `WalletConnectionIndicator.tsx` now surfaces the real wallet name + shortened address instead of just "Connected".
- Extended `lib/user-session-sync.ts` to persist `walletAddress` / `walletName` / `walletChain` alongside the existing connected flag.

## Notes for reviewers
- Dependencies were added to `package.json` but `npm install` was not run — no lockfile update yet.
- No organizer payout address exists in the data model yet, so the default (no-argument) `signTransaction()` call signs a minimal real self-payment (1 stroop, memo `zicket-ticket`) purely to produce a verifiable on-chain transaction. Once ticket purchases have a real destination (organizer wallet + priced asset), build that XDR and pass it into `signTransaction(xdr)`.
- Aztec/Azguard method names in `lib/wallet/aztecAdapter.ts` are a best-effort based on the injected-provider convention other wallets use — verify against current Azguard/`@aztec/aztec.js` docs before shipping.
- `NEXT_PUBLIC_STELLAR_NETWORK`, `NEXT_PUBLIC_STELLAR_HORIZON_URL`, and `NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID` are documented in `.env.example`.

Closes #186 
Closes #187 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Stellar and Aztec wallet connections.
  * Wallet indicators now show the connected wallet name and shortened address.
  * Added wallet and network configuration options.
  * Stellar transactions now report confirmed, failed, or pending status from the network.
  * Added improved wallet selection and transaction signing flows.

* **Bug Fixes**
  * Improved sold-out ticket handling, accessibility labels, and wallet loading behavior.

* **Tests**
  * Added automated coverage for event filtering, ticket checkout, wallet flows, and end-to-end purchases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->